### PR TITLE
Revert "Change Middleware error handling"

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
@@ -16,7 +16,4 @@ interface Middleware<S : State, A : Action, E : Event> {
     suspend fun afterStateChange(state: S, prevState: S) {}
     suspend fun beforeError(state: S, error: Throwable) {}
     suspend fun afterError(state: S, nextState: S, error: Throwable) {}
-    suspend fun onMiddlewareError(throwable: Throwable) {
-        throw throwable
-    }
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
@@ -207,13 +207,7 @@ open class TartStore<S : State, A : Action, E : Event> internal constructor(
         try {
             coroutineScope {
                 middlewares.map {
-                    launch {
-                        try {
-                            block(it)
-                        } catch (t: Throwable) {
-                            it.onMiddlewareError(t)
-                        }
-                    }
+                    launch { block(it) }
                 }
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
It is complicated to deal with Middleware's own CoroutineScope, so simply propagate all errors to the top level.