### PR TITLE
Remove functional interfaces

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
@@ -219,9 +219,7 @@ open class TartStore<S : State, A : Action, E : Event> internal constructor(
         processEventEmit(currentState, event)
     }
 
-    protected fun interface EmitFun<E> {
-        suspend operator fun invoke(event: E)
-    }
-
     private class MiddlewareError(val original: Throwable) : Throwable(original)
 }
+
+typealias EmitFun<T> = suspend (T) -> Unit

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
@@ -44,10 +44,6 @@ abstract class MessageSendMiddleware<S : State, A : Action, E : Event> : Middlew
         MessageHub.send(message)
     }
 
-    protected fun interface SendFun {
-        suspend operator fun invoke(message: Message)
-    }
-
     final override suspend fun beforeActionDispatch(state: S, action: A) {}
     final override suspend fun afterActionDispatch(state: S, action: A, nextState: S) {}
     final override suspend fun beforeEventEmit(state: S, event: E) {}
@@ -86,3 +82,5 @@ abstract class MessageReceiveMiddleware<S : State, A : Action, E : Event> : Midd
     final override suspend fun beforeError(state: S, error: Throwable) {}
     final override suspend fun afterError(state: S, nextState: S, error: Throwable) {}
 }
+
+typealias SendFun = suspend (Message) -> Unit


### PR DESCRIPTION
Because it is difficult to delegate to another process.