### PR TITLE
Remove processInitialStateEnter option as it is redundant

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -26,13 +26,11 @@ interface Store<S : State, A : Action, E : Event> {
     @Suppress("unused")
     abstract class Base<S : State, A : Action, E : Event>(
         initialState: S,
-        processInitialStateEnter: Boolean = true,
         latestState: suspend (state: S) -> Unit = {},
         onError: (error: Throwable) -> Unit = { throw it },
         coroutineContext: CoroutineContext = Dispatchers.Default,
     ) : TartStore<S, A, E>(
         initialState = initialState,
-        processInitialStateEnter = processInitialStateEnter,
         latestState = latestState,
         onError = onError,
         coroutineContext = coroutineContext,

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt
@@ -17,7 +17,6 @@ import kotlin.coroutines.CoroutineContext
 
 open class TartStore<S : State, A : Action, E : Event> internal constructor(
     private val initialState: S,
-    private val processInitialStateEnter: Boolean,
     private val latestState: suspend (state: S) -> Unit,
     onError: (error: Throwable) -> Unit,
     coroutineContext: CoroutineContext,
@@ -84,13 +83,12 @@ open class TartStore<S : State, A : Action, E : Event> internal constructor(
             mutex.withLock {
                 try {
                     processMiddleware { onInit(this@TartStore, coroutineScope.coroutineContext) }
-                } catch (e: MiddlewareError) {
-                    throw e.original
-                } catch (t: Throwable) {
-                    throw t
-                }
-                if (processInitialStateEnter) {
                     onStateEntered(initialState)
+                } catch (t: Throwable) {
+                    if (t is MiddlewareError) {
+                        throw t.original
+                    }
+                    throw t
                 }
             }
         }


### PR DESCRIPTION
If you don't want it to start automatically, don't override onEnter().