### PR TITLE
docs: fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Therefore, if you prepare only the *State*, it is possible to develop the UI.
 ## Middleware
 
 <details>
-<summary>contens</summary>
+<summary>contents</summary>
 
 You can create extensions that work with the *Store*.
 To do this, create a class that implements the `Middleware` interface and override the necessary methods.


### PR DESCRIPTION
When I was reading README.md to refer to the code here, 
I found a typo in README.md and corrected it.