### PR TITLE
refactor: improve API consistency and usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ viewStore.handle<CounterEvent> { event ->
 
 ### Mock for preview and testing
 
-Create an instance of ViewStore using the `mock()` with target *State*.
+Create an instance of ViewStore using the `viewStore()` with target *State*.
 You can statically create a ViewStore instance without a *Store* instance.
 
 ```kt
@@ -557,7 +557,7 @@ You can statically create a ViewStore instance without a *Store* instance.
 fun LoadingPreview() {
     MyApplicationTheme {
         YourComposable(
-            viewStore = ViewStore.mock(
+            viewStore = viewStore(
                 state = CounterState.Loading,
             ),
         )

--- a/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
+++ b/tart-compose/src/commonMain/kotlin/io/yumemi/tart/compose/ViewStore.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.filter
 
 @Suppress("unused")
 @Stable
-class ViewStore<S : State, A : Action, E : Event> private constructor(
+class ViewStore<S : State, A : Action, E : Event> internal constructor(
     val state: S,
     val dispatch: (action: A) -> Unit,
     val eventFlow: Flow<E>,
@@ -46,7 +46,7 @@ class ViewStore<S : State, A : Action, E : Event> private constructor(
         if (state is S2) {
             block(
                 remember(state) {
-                    create(
+                    viewStore(
                         state = state,
                         dispatch = dispatch,
                         eventFlow = eventFlow,
@@ -66,6 +66,7 @@ class ViewStore<S : State, A : Action, E : Event> private constructor(
     }
 
     companion object {
+        @Deprecated("Use viewStore() function instead")
         fun <S : State, A : Action, E : Event> create(state: S, dispatch: (action: A) -> Unit, eventFlow: Flow<E>): ViewStore<S, A, E> {
             return ViewStore(
                 state = state,
@@ -74,6 +75,7 @@ class ViewStore<S : State, A : Action, E : Event> private constructor(
             )
         }
 
+        @Deprecated("Use viewStore() function instead")
         fun <S : State, A : Action, E : Event> mock(state: S): ViewStore<S, A, E> {
             return ViewStore(
                 state = state,
@@ -82,6 +84,14 @@ class ViewStore<S : State, A : Action, E : Event> private constructor(
             )
         }
     }
+}
+
+fun <S : State, A : Action, E : Event> viewStore(state: S, dispatch: (action: A) -> Unit = {}, eventFlow: Flow<E> = emptyFlow()): ViewStore<S, A, E> {
+    return ViewStore(
+        state = state,
+        dispatch = dispatch,
+        eventFlow = eventFlow,
+    )
 }
 
 @Suppress("unused")
@@ -100,7 +110,7 @@ fun <S : State, A : Action, E : Event> rememberViewStore(store: Store<S, A, E>, 
     }
 
     return remember(state) {
-        ViewStore.create(
+        ViewStore(
             state = state,
             dispatch = rememberStore::dispatch,
             eventFlow = rememberStore.event,
@@ -133,7 +143,7 @@ fun <S : State, A : Action, E : Event> rememberViewStore(saver: Saver<S?, out An
     }
 
     return remember(state) {
-        ViewStore.create(
+        ViewStore(
             state = state,
             dispatch = store::dispatch,
             eventFlow = store.event,
@@ -192,7 +202,7 @@ fun <S : State, A : Action, E : Event> rememberViewStoreSaveable(
     }
 
     return remember(state) {
-        ViewStore.create(
+        ViewStore(
             state = state,
             dispatch = store::dispatch,
             eventFlow = store.event,

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
@@ -6,7 +6,7 @@ interface StateSaver<S : State> {
 }
 
 @Suppress("unused")
-fun <S : State> StateSaver(
+fun <S : State> stateSaver(
     save: (state: S) -> Unit,
     restore: () -> S?,
 ): StateSaver<S> {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt
@@ -35,7 +35,7 @@ interface Store<S : State, A : Action, E : Event> {
     )
 
     companion object {
-        @Suppress("unused")
+        @Deprecated("Use store() function instead")
         fun <S : State, A : Action, E : Event> mock(state: S): Store<S, A, E> {
             return object : Store<S, A, E> {
                 override val state: StateFlow<S> = MutableStateFlow(state)
@@ -47,5 +47,18 @@ interface Store<S : State, A : Action, E : Event> {
                 override fun dispose() {}
             }
         }
+    }
+}
+
+@Suppress("unused")
+fun <S : State, A : Action, E : Event> store(state: S): Store<S, A, E> {
+    return object : Store<S, A, E> {
+        override val state: StateFlow<S> = MutableStateFlow(state)
+        override val event: Flow<E> = emptyFlow()
+        override val currentState: S = state
+        override fun dispatch(action: A) {}
+        override fun collectState(skipInitialState: Boolean, startStore: Boolean, state: (state: S) -> Unit) {}
+        override fun collectEvent(event: (event: E) -> Unit) {}
+        override fun dispose() {}
     }
 }

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/DefaultLogger.kt
@@ -3,7 +3,7 @@ package io.yumemi.tart.logging
 import co.touchlab.kermit.Severity
 import co.touchlab.kermit.Logger.Companion as Kermit
 
-class TartLogger : Logger {
+class DefaultLogger : Logger {
     override suspend fun log(severity: Logger.Severity, tag: String, throwable: Throwable?, message: String) {
         if (isDisabled) return
         Kermit.log(

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.CoroutineContext
 
 @Suppress("unused")
 open class LoggingMiddleware<S : State, A : Action, E : Event>(
-    private val logger: Logger = TartLogger(),
+    private val logger: Logger = DefaultLogger(),
     private val tag: String = "Tart",
     private val severity: Logger.Severity = Logger.Severity.Debug,
 ) : Middleware<S, A, E> {
@@ -45,4 +45,17 @@ open class LoggingMiddleware<S : State, A : Action, E : Event>(
             logger.log(severity = severity, tag = tag, throwable = throwable, message = message())
         }
     }
+}
+
+@Suppress("unused")
+fun <S : State, A : Action, E : Event> defaultLoggingMiddleware(
+    logger: Logger = DefaultLogger(),
+    tag: String = "Tart",
+    severity: Logger.Severity = Logger.Severity.Debug,
+): LoggingMiddleware<S, A, E> {
+    return object : LoggingMiddleware<S, A, E>(
+        logger = logger,
+        tag = tag,
+        severity = severity,
+    ) {}
 }

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
@@ -52,3 +52,14 @@ abstract class MessageMiddleware<S : State, A : Action, E : Event> : Middleware<
 suspend fun send(message: Message) {
     MessageHub.send(message = message)
 }
+
+@Suppress("unused")
+fun <S : State, A : Action, E : Event> messageMiddleware(
+    receive: suspend (message: Message, dispatch: (action: A) -> Unit) -> Unit,
+): Middleware<S, A, E> {
+    return object : MessageMiddleware<S, A, E>() {
+        override suspend fun receive(message: Message, dispatch: (action: A) -> Unit) {
+            receive.invoke(message, dispatch)
+        }
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the `tart` project, focusing on improving the creation and usage of `ViewStore`, updating logging mechanisms, and adding new utility functions. The most important changes include deprecating old methods, introducing new factory functions, and renaming classes for clarity.

### ViewStore and State Management Updates:
* Deprecated the `ViewStore.create` and `ViewStore.mock` methods in favor of the new `viewStore` function. [[1]](diffhunk://#diff-e5c0198e3117fc7f2d55a664452c96c5a6f5e1bb57595acf59124500e6f610f1R69) [[2]](diffhunk://#diff-e5c0198e3117fc7f2d55a664452c96c5a6f5e1bb57595acf59124500e6f610f1R78)
* Changed the `ViewStore` constructor from `private` to `internal` to restrict its visibility.
* Updated the `README.md` to reflect the new `viewStore` function usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L551-R551) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L560-R560)

### Logging Enhancements:
* Renamed the `TartLogger` class to `DefaultLogger` for better clarity.
* Updated `LoggingMiddleware` to use `DefaultLogger` as the default logger.
* Added a new utility function `defaultLoggingMiddleware` to create instances of `LoggingMiddleware`.

### Store and Middleware Improvements:
* Deprecated the `Store.mock` method and introduced the `store` function as a replacement. [[1]](diffhunk://#diff-7bd13830d9d6580d4d23c75804de79d7424f81419be204efe7e30ed92a202c4eL38-R38) [[2]](diffhunk://#diff-7bd13830d9d6580d4d23c75804de79d7424f81419be204efe7e30ed92a202c4eR52-R64)
* Added a new utility function `messageMiddleware` to simplify the creation of `MessageMiddleware` instances.

These changes aim to enhance the clarity, usability, and maintainability of the codebase.