### PR TITLE
Align job name with its actual function: build → test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,11 @@ on:
   release:
     types: [ prereleased ]
 jobs:
-  build:
+  test:
     uses: ./.github/workflows/gradle.yml
   publish:
     name: Release build and publish
-    needs: build
+    needs: test
     runs-on: macOS-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration in the `.github/workflows/publish.yml` file. The change renames the `build` job to `test` and updates the `publish` job to depend on the `test` job instead of the `build` job.

Workflow configuration changes:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L6-R10): Renamed the `build` job to `test` and updated the `publish` job to depend on the `test` job.