### PR TITLE
Add StateSaver support to Store

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
@@ -1,0 +1,13 @@
+package io.yumemi.tart.core
+
+interface ExceptionHandler {
+    fun handle(error: Throwable)
+}
+
+fun exceptionHandler(block: (error: Throwable) -> Unit): ExceptionHandler {
+    return object : ExceptionHandler {
+        override fun handle(error: Throwable) {
+            block.invoke(error)
+        }
+    }
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StateSaver.kt
@@ -5,7 +5,6 @@ interface StateSaver<S : State> {
     fun restore(): S?
 }
 
-@Suppress("unused")
 fun <S : State> stateSaver(
     save: (state: S) -> Unit,
     restore: () -> S?,


### PR DESCRIPTION
This pull request includes significant changes to the `Store` and `TartStore` classes in the `tart-core` module. The changes mainly involve refactoring the error handling mechanism, state management, and middleware handling.

### Error Handling and State Management:

* [`tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Store.kt`](diffhunk://#diff-7bd13830d9d6580d4d23c75804de79d7424f81419be204efe7e30ed92a202c4eL30-R39): Deprecated the `onError` parameter in the `Base` class and introduced an `exceptionHandler` for handling exceptions. Additionally, added a `stateSaver` for state persistence.

* [`tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt`](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196L20-R38): Refactored the `TartStore` class to use an abstract `exceptionHandler` and `stateSaver` for improved error handling and state restoration. The `onError` parameter is now deprecated. [[1]](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196L20-R38) [[2]](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196L36-R54)

### Middleware Handling:

* [`tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt`](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196L36-R54): Changed the `middlewares` property from `protected open` to `protected abstract` to enforce implementation in subclasses.

### State Management:

* [`tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt`](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196R206-R210): Updated the `processStateChange` method to save the new state using the `stateSaver` and handle any potential errors by throwing an `InternalError`.

### Miscellaneous:

* [`tart-core/src/commonMain/kotlin/io/yumemi/tart/core/TartStore.kt`](diffhunk://#diff-a4e407018c4788194c6b358ac5fc9d6d9b971024dd3806d1b56c2dbd971bf196L92-R106): Modified the `onStateEntered` call to use `currentState` instead of `initialState` to reflect the accurate state.