### PR TITLE
Bump AGP from 8.6.1 to 8.6.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 tart = "1.4.0"
-agp = "8.6.1"
+agp = "8.6.2"
 kotlin = "2.0.20"
 coroutines = "1.9.0"
 kermit = "1.2.2"


### PR DESCRIPTION
To the latest version of 8.6.x.