### PR TITLE
Change project configuration

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,11 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      # FIXME: comment out because it frequently fails
-      #   It might be fixed by implementing the following:
-      #     https://github.com/Kotlin/multiplatform-library-template/commit/4eea4b868d1a1cf323242cf414ac5d358c671dca
-      # - name: Validate Gradle Wrapper
-      #   uses: gradle/wrapper-validation-action@v1
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
       - uses: actions/cache@v3
         with:
           path: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.parallel=true
 # Kotlin
 kotlin.code.style=official
 # kotlin.js.compiler=ir // Deprecated: IR compiler is the default and only option since Kotlin 2.0, and this project doesn't use JS target anyway

--- a/tart-compose/build.gradle.kts
+++ b/tart-compose/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -15,7 +14,6 @@ version = libs.versions.tart.get()
 kotlin {
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }

--- a/tart-core/build.gradle.kts
+++ b/tart-core/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -13,7 +12,6 @@ version = libs.versions.tart.get()
 kotlin {
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }

--- a/tart-logging/build.gradle.kts
+++ b/tart-logging/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -13,7 +12,6 @@ version = libs.versions.tart.get()
 kotlin {
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }

--- a/tart-message/build.gradle.kts
+++ b/tart-message/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -13,7 +12,6 @@ version = libs.versions.tart.get()
 kotlin {
     androidTarget {
         publishLibraryVariants("release")
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }


### PR DESCRIPTION
This pull request includes several changes to the Gradle configuration and Kotlin build scripts to improve build stability and performance. The most important changes include re-enabling the Gradle Wrapper validation, enabling parallel execution in Gradle, and removing the usage of an experimental Kotlin Gradle plugin API.

Improvements to Gradle configuration:

* [`.github/workflows/gradle.yml`](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325L35-R36): Re-enabled the Gradle Wrapper validation step by updating the action to `gradle/actions/wrapper-validation@v3`.
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R5): Enabled parallel execution in Gradle by adding `org.gradle.parallel=true`.

Simplification of Kotlin build scripts:

* `tart-compose/build.gradle.kts`, `tart-core/build.gradle.kts`, `tart-logging/build.gradle.kts`, `tart-message/build.gradle.kts`: Removed the import and usage of `ExperimentalKotlinGradlePluginApi` annotation. [[1]](diffhunk://#diff-702872ff974445014c2ad0c732d712990a16284a118b4edca48621c485fb8941L1) [[2]](diffhunk://#diff-702872ff974445014c2ad0c732d712990a16284a118b4edca48621c485fb8941L18) [[3]](diffhunk://#diff-e6567b0f8df664fd34b3534878a25d03f367ccc80ebb62071412b031ed647c0fL1) [[4]](diffhunk://#diff-e6567b0f8df664fd34b3534878a25d03f367ccc80ebb62071412b031ed647c0fL16) [[5]](diffhunk://#diff-833830bf5c89c5d9a5de6632b07512eb4bbd0804108cb1b24b6b82318231e791L1) [[6]](diffhunk://#diff-833830bf5c89c5d9a5de6632b07512eb4bbd0804108cb1b24b6b82318231e791L16) [[7]](diffhunk://#diff-cf31fe41271f60c74f076b319fc7c5e60128e5352247dd72ff717f3af5565ea8L1) [[8]](diffhunk://#diff-cf31fe41271f60c74f076b319fc7c5e60128e5352247dd72ff717f3af5565ea8L16)