### PR TITLE
Add test codes to tart-core module

### DIFF
--- a/tart-compose/src/commonTest/kotlin/io/yumemi/tart/compose/ViewStoreTest.kt
+++ b/tart-compose/src/commonTest/kotlin/io/yumemi/tart/compose/ViewStoreTest.kt
@@ -1,7 +1,5 @@
 package io.yumemi.tart.compose
 
-import io.yumemi.tart.core.Action
-import io.yumemi.tart.core.Event
 import io.yumemi.tart.core.State
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -16,9 +14,9 @@ class ViewStoreTest {
 
     @Test
     fun viewStore_equalsWorksCorrectly() = runTest(testDispatcher) {
-        val viewStore1 = ViewStore<CounterState, CounterAction, CounterEvent>(CounterState(10))
-        val viewStore2 = ViewStore<CounterState, CounterAction, CounterEvent>(CounterState(10))
-        val viewStore3 = ViewStore<CounterState, CounterAction, CounterEvent>(CounterState(20))
+        val viewStore1 = ViewStore<CounterState, Nothing, Nothing>(CounterState(10))
+        val viewStore2 = ViewStore<CounterState, Nothing, Nothing>(CounterState(10))
+        val viewStore3 = ViewStore<CounterState, Nothing, Nothing>(CounterState(20))
 
         assertEquals(viewStore1, viewStore2)
         assertNotEquals(viewStore1, viewStore3)
@@ -26,5 +24,3 @@ class ViewStoreTest {
 }
 
 private data class CounterState(val count: Int) : State
-private interface CounterAction : Action
-private interface CounterEvent : Event

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -13,7 +13,7 @@ class StoreBaseTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun tartStore_shouldHandleMultipleActions() = runTest(testDispatcher) {
+    fun tartStore_shouldHandleActions() = runTest(testDispatcher) {
         val store = createTestStore(CounterState.Main(0))
 
         store.dispatch(CounterAction.Increment)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
@@ -1,0 +1,43 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class StoreExceptionTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun store_shouldUseExceptionHandlerOnError() = runTest(testDispatcher) {
+        var handledException: Throwable? = null
+
+        val store = createTestStore(
+            initialState = ExceptionState(0),
+            exceptionHandler = ExceptionHandler { error ->
+                handledException = error
+            },
+        )
+
+        store.state // access state to initialize the store
+
+        assertNotNull(handledException)
+    }
+}
+
+private data class ExceptionState(val value: Int) : State
+
+private fun createTestStore(
+    initialState: ExceptionState,
+    exceptionHandler: ExceptionHandler,
+): Store<ExceptionState, Nothing, Nothing> {
+    return object : Store.Base<ExceptionState, Nothing, Nothing>(initialState, Dispatchers.Unconfined) {
+        override val exceptionHandler: ExceptionHandler = exceptionHandler
+        override suspend fun onEnter(state: ExceptionState): ExceptionState {
+            throw RuntimeException("error")
+        }
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
@@ -1,0 +1,51 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class StoreSaverTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun store_shouldUseStateSaverToRestoreState() = runTest(testDispatcher) {
+        var savedState = SaverState(10)
+
+        val stateSaver = StateSaver(
+            save = { state -> savedState = state },
+            restore = { savedState },
+        )
+
+        val store = createTestStore(SaverState(0), stateSaver)
+
+        assertEquals(SaverState(10), store.currentState)
+
+        store.dispatch(SaverAction.Update(20))
+
+        assertEquals(SaverState(20), savedState)
+    }
+}
+
+private data class SaverState(val value: Int) : State
+
+private sealed interface SaverAction : Action {
+    data class Update(val value: Int) : SaverAction
+}
+
+private fun createTestStore(
+    initialState: SaverState,
+    stateSaver: StateSaver<SaverState>,
+): Store<SaverState, SaverAction, Nothing> {
+    return object : Store.Base<SaverState, SaverAction, Nothing>(initialState, Dispatchers.Unconfined) {
+        override val stateSaver = stateSaver
+        override suspend fun onDispatch(state: SaverState, action: SaverAction): SaverState {
+            return when (action) {
+                is SaverAction.Update -> SaverState(action.value)
+            }
+        }
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreTransitionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreTransitionTest.kt
@@ -1,0 +1,69 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class StoreTransitionTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun tartStore_shouldTransitionBetweenStates() = runTest(testDispatcher) {
+        val store = createTestStore(TransitionState.Loading)
+
+        assertEquals(TransitionState.Success, store.state.value)
+    }
+
+    @Test
+    fun tartStore_shouldTransitionToErrorState() = runTest(testDispatcher) {
+        val store = createTestStore(TransitionState.Loading)
+
+        store.dispatch(TransitionAction.CauseError)
+
+        assertTrue(store.currentState is TransitionState.Error)
+    }
+}
+
+private sealed interface TransitionState : State {
+    data object Loading : TransitionState
+    data object Success : TransitionState
+    data class Error(val message: String) : TransitionState
+}
+
+private sealed interface TransitionAction : Action {
+    data object CauseError : TransitionAction
+}
+
+private fun createTestStore(
+    initialState: TransitionState,
+): Store<TransitionState, TransitionAction, Nothing> {
+    return object : Store.Base<TransitionState, TransitionAction, Nothing>(initialState, Dispatchers.Unconfined) {
+        override suspend fun onEnter(state: TransitionState): TransitionState {
+            return when (state) {
+                TransitionState.Loading -> TransitionState.Success
+                else -> state
+            }
+        }
+
+        override suspend fun onDispatch(state: TransitionState, action: TransitionAction): TransitionState {
+            return when (state) {
+                TransitionState.Success -> {
+                    when (action) {
+                        TransitionAction.CauseError -> throw RuntimeException("error")
+                    }
+                }
+
+                else -> state
+            }
+        }
+
+        override suspend fun onError(state: TransitionState, error: Throwable): TransitionState {
+            return TransitionState.Error(error.message ?: "unknown error")
+        }
+    }
+}

--- a/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
+++ b/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
@@ -1,7 +1,6 @@
 package io.yumemi.tart.logging
 
 import io.yumemi.tart.core.Action
-import io.yumemi.tart.core.Event
 import io.yumemi.tart.core.Middleware
 import io.yumemi.tart.core.State
 import io.yumemi.tart.core.Store
@@ -19,7 +18,7 @@ class LoggingMiddlewareTest {
     @Test
     fun loggingMiddleware_shouldLogAction() = runTest(testDispatcher) {
         val testLogger = TestLogger()
-        val middleware = LoggingMiddleware<CounterState, CounterAction, CounterEvent>(
+        val middleware = LoggingMiddleware<CounterState, CounterAction, Nothing>(
             logger = testLogger,
             coroutineDispatcher = Dispatchers.Unconfined,
         )
@@ -34,12 +33,11 @@ class LoggingMiddlewareTest {
 }
 
 private data class CounterState(val count: Int) : State
+
 private sealed interface CounterAction : Action {
     data object Increment : CounterAction
     data object Decrement : CounterAction
 }
-
-private interface CounterEvent : Event
 
 private class TestLogger : Logger {
     val logs = mutableListOf<String>()
@@ -50,9 +48,9 @@ private class TestLogger : Logger {
 
 private fun createTestStore(
     initialState: CounterState,
-    middleware: Middleware<CounterState, CounterAction, CounterEvent>,
-): Store<CounterState, CounterAction, CounterEvent> {
-    return object : Store.Base<CounterState, CounterAction, CounterEvent>(initialState, Dispatchers.Unconfined) {
+    middleware: Middleware<CounterState, CounterAction, Nothing>,
+): Store<CounterState, CounterAction, Nothing> {
+    return object : Store.Base<CounterState, CounterAction, Nothing>(initialState, Dispatchers.Unconfined) {
         override val middlewares = listOf(middleware)
         override suspend fun onDispatch(state: CounterState, action: CounterAction): CounterState {
             return when (action) {

--- a/tart-message/src/commonTest/kotlin/io/yumemi/tart/message/MessageMiddlewareTest.kt
+++ b/tart-message/src/commonTest/kotlin/io/yumemi/tart/message/MessageMiddlewareTest.kt
@@ -1,7 +1,5 @@
 package io.yumemi.tart.message
 
-import io.yumemi.tart.core.Action
-import io.yumemi.tart.core.Event
 import io.yumemi.tart.core.Middleware
 import io.yumemi.tart.core.State
 import io.yumemi.tart.core.Store
@@ -21,7 +19,7 @@ class MessageMiddlewareTest {
         val sendMessage = TestMessage("Hello")
 
         var receivedMessage: TestMessage? = null
-        val middleware = MessageMiddleware<CounterState, CounterAction, CounterEvent> { message, _ ->
+        val middleware = MessageMiddleware<CounterState, Nothing, Nothing> { message, _ ->
             if (message is TestMessage) {
                 receivedMessage = message
             }
@@ -29,28 +27,23 @@ class MessageMiddlewareTest {
 
         val store = createTestStore(CounterState(10), middleware)
 
-        // Access state to initialize the store
-        store.state
+        store.state // access state to initialize the store
 
-        // Send a message
         MessageHub.send(sendMessage)
 
-        // Verify message was received
         assertEquals(sendMessage, receivedMessage)
     }
 }
 
 private data class CounterState(val count: Int) : State
-private interface CounterAction : Action
-private interface CounterEvent : Event
 
 private data class TestMessage(val value: String) : Message
 
 private fun createTestStore(
     initialState: CounterState,
-    middleware: Middleware<CounterState, CounterAction, CounterEvent>,
-): Store<CounterState, CounterAction, CounterEvent> {
-    return object : Store.Base<CounterState, CounterAction, CounterEvent>(initialState, Dispatchers.Unconfined) {
+    middleware: Middleware<CounterState, Nothing, Nothing>,
+): Store<CounterState, Nothing, Nothing> {
+    return object : Store.Base<CounterState, Nothing, Nothing>(initialState, Dispatchers.Unconfined) {
         override val middlewares = listOf(middleware)
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the test coverage and simplify the codebase by removing unused interfaces and modifying test cases. The most important changes include adding new test classes, updating existing test cases, and removing unnecessary imports and interfaces.

### Additions:
* Added new test class `StoreExceptionTest` to test the exception handling in the store.
* Added new test class `StoreSaverTest` to test the state saving and restoring functionality in the store.
* Added new test class `StoreTransitionTest` to test state transitions in the store.

### Updates to existing test cases:
* Updated `ViewStoreTest` to remove `CounterAction` and `CounterEvent` interfaces and use `Nothing` for action and event types.
* Modified `StoreBaseTest` to rename the test method `tartStore_shouldHandleMultipleActions` to `tartStore_shouldHandleActions`.
* Updated `LoggingMiddlewareTest` to remove `CounterEvent` interface and use `Nothing` for event type.
* Updated `MessageMiddlewareTest` to remove `CounterAction` and `CounterEvent` interfaces and use `Nothing` for action and event types.

### Codebase simplification:
* Removed unused imports of `Action` and `Event` in several test files (`ViewStoreTest.kt`, `LoggingMiddlewareTest.kt`, `MessageMiddlewareTest.kt`). [[1]](diffhunk://#diff-ab15092ba78b80118c856038b4595ce6083f1baa9a59251952a2b21cecd7d17eL3-L4) [[2]](diffhunk://#diff-af474e21893c920dcf184a154ef28c8cc85b3f150fbe552f6e931d93fa94de9fL4) [[3]](diffhunk://#diff-c0675503466790fd05deb1b4143c7af8671ec76898addd17bfe34120f0300815L3-L4)