### PR TITLE
Refactor Context APIs to use state.update() pattern

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
@@ -85,7 +85,7 @@ interface ActionContext<S : State, A : Action, E : Event> : StoreContext {
  * Context available when an error occurs in a state handler.
  * Used in error handlers to recover from errors or update state accordingly.
  */
-interface ErrorContext<S : State, A : Action, E : Event> : StoreContext {
+interface ErrorContext<S : State, A : Action, E : Event, S0 : State> : StoreContext {
     /**
      * The current state when the error occurred
      */
@@ -100,6 +100,14 @@ interface ErrorContext<S : State, A : Action, E : Event> : StoreContext {
      * Function to emit events from the error handler
      */
     val emit: suspend (E) -> Unit
+
+    /**
+     * Updates the current state with a new state value.
+     * Used within error handlers to modify the state.
+     *
+     * @param state The new state value to update to
+     */
+    fun S.update(state: S0)
 }
 
 /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
@@ -1,6 +1,5 @@
 package io.yumemi.tart.core
 
-import kotlinx.coroutines.CoroutineScope
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -13,7 +12,7 @@ sealed interface StoreContext
  * Context available when a state is being entered.
  * Used in enter handlers to manage state transitions and side effects.
  */
-interface EnterContext<S : State, A : Action, E : Event> : StoreContext {
+interface EnterContext<S : State, A : Action, E : Event, S0 : State> : StoreContext {
     /**
      * The current state that's being entered
      */
@@ -35,6 +34,14 @@ interface EnterContext<S : State, A : Action, E : Event> : StoreContext {
      * Function to dispatch actions from the enter handler
      */
     val dispatch: (A) -> Unit
+
+    /**
+     * Updates the current state with a new state value.
+     * Used within enter handlers to modify the state.
+     *
+     * @param state The new state value to update to
+     */
+    fun S.update(state: S0)
 }
 
 /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreContext.kt
@@ -64,7 +64,7 @@ interface ExitContext<S : State, A : Action, E : Event> : StoreContext {
  * Context available when an action is being processed.
  * Used in action handlers to update state based on an action.
  */
-interface ActionContext<S : State, A : Action, E : Event> : StoreContext {
+interface ActionContext<S : State, A : Action, E : Event, S0 : State> : StoreContext {
     /**
      * The current state when the action is being processed
      */
@@ -79,6 +79,14 @@ interface ActionContext<S : State, A : Action, E : Event> : StoreContext {
      * Function to emit events from the action handler
      */
     val emit: suspend (E) -> Unit
+
+    /**
+     * Updates the current state with a new state value.
+     * Used within action handlers to modify the state.
+     *
+     * @param state The new state value to update to
+     */
+    fun S.update(state: S0)
 }
 
 /**

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -234,7 +234,7 @@ private fun createCounterStore(
             }
             error {
                 emit(CounterEvent.ErrorOccurred(error.message ?: "Unknown error"))
-                CounterState.Error(error.message ?: "Unknown error")
+                state.update(CounterState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -190,7 +190,6 @@ private fun createCounterStore(
             enter {
                 // Optional initialization when entering active state
                 emit(CounterEvent.CountChanged(state.count))
-                state
             }
 
             action<CounterAction.Increment> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -181,7 +181,7 @@ private fun createCounterStore(
         // Initial state handling
         state<CounterState.Initial> {
             action<CounterAction.Start> {
-                CounterState.Active(0)
+                state.update(CounterState.Active(0))
             }
         }
 
@@ -201,29 +201,29 @@ private fun createCounterStore(
                     emit(CounterEvent.ThresholdReached(10))
                 }
 
-                state.copy(count = newCount)
+                state.update(state.copy(count = newCount))
             }
 
             action<CounterAction.Decrement> {
                 val newCount = state.count - 1
                 emit(CounterEvent.CountChanged(newCount))
-                state.copy(count = newCount)
+                state.update(state.copy(count = newCount))
             }
 
             action<CounterAction.Reset> {
                 emit(CounterEvent.CountChanged(0))
-                state.copy(count = 0)
+                state.update(state.copy(count = 0))
             }
 
             action<CounterAction.Pause> {
-                CounterState.Paused(state.count)
+                state.update(CounterState.Paused(state.count))
             }
         }
 
         // Paused state handling
         state<CounterState.Paused> {
             action<CounterAction.Resume> {
-                CounterState.Active(state.count)
+                state.update(CounterState.Active(state.count))
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
@@ -125,7 +125,7 @@ private fun createFlowCollectStore(
         // Initial state handling
         state<FlowState.Initial> {
             action<FlowAction.StartCollecting> {
-                FlowState.Active(0) // Start with a default value before flow collection
+                state.update(FlowState.Active(0)) // Start with a default value before flow collection
             }
         }
 
@@ -143,11 +143,11 @@ private fun createFlowCollectStore(
 
             action<FlowAction.UpdateValue> {
                 // Update state with the latest value from flow
-                state.copy(value = action.value)
+                state.update(state.copy(value = action.value))
             }
 
             action<FlowAction.Complete> {
-                FlowState.Completed
+                state.update(FlowState.Completed)
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -140,9 +139,6 @@ private fun createFlowCollectStore(
                         dispatch(FlowAction.UpdateValue(value))
                     }
                 }
-
-                // Return current state
-                state
             }
 
             action<FlowAction.UpdateValue> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -142,9 +142,9 @@ private fun createLoginStore(
             action<LoginAction.Login> {
                 // Validation check
                 if (action.username.isNotBlank() && action.password.isNotBlank()) {
-                    LoginState.Loading(action.username, action.password)
+                    state.update(LoginState.Loading(action.username, action.password))
                 } else {
-                    LoginState.Error("Username and password must not be empty")
+                    state.update(LoginState.Error("Username and password must not be empty"))
                 }
             }
         }
@@ -164,7 +164,7 @@ private fun createLoginStore(
         // Processing for Error state
         state<LoginState.Error> {
             action<LoginAction.RetryFromError> {
-                LoginState.Initial
+                state.update(LoginState.Initial)
             }
         }
         // Error handling for all states

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -170,7 +170,7 @@ private fun createLoginStore(
         // Error handling for all states
         state<LoginState> {
             error {
-                LoginState.Error(error.message ?: "Unknown error")
+                state.update(LoginState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -155,9 +155,9 @@ private fun createLoginStore(
                 val success = repository.login(state.username, state.password)
                 if (success) {
                     emit(LoginEvent.NavigateToHome(state.username))
-                    LoginState.Success(state.username)
+                    state.update(LoginState.Success(state.username))
                 } else {
-                    LoginState.Error("Authentication failed")
+                    state.update(LoginState.Error("Authentication failed"))
                 }
             }
         }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -62,7 +62,7 @@ private fun createTestStore(
         coroutineContext(Dispatchers.Unconfined)
         state<BaseState.Loading> {
             enter {
-                BaseState.Main(count = 0)
+                state.update(BaseState.Main(count = 0))
             }
         }
         state<BaseState.Main> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -67,14 +67,13 @@ private fun createTestStore(
         }
         state<BaseState.Main> {
             action<BaseAction.Increment> {
-                state.copy(count = state.count + 1)
+                state.update(state.copy(count = state.count + 1))
             }
             action<BaseAction.Decrement> {
-                state.copy(count = state.count - 1)
+                state.update(state.copy(count = state.count - 1))
             }
             action<BaseAction.EmitEvent> {
                 emit(BaseEvent.CountUpdated(state.count))
-                state
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
@@ -45,7 +45,7 @@ private fun createTestStore(
         stateSaver(stateSaver)
         state<SaverState> {
             action<SaverAction.Update> {
-                state.copy(value = action.value)
+                state.update(state.copy(value = action.value))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -3,7 +3,6 @@ package io.yumemi.tart.core
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -134,9 +133,6 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
                     // Emit event
                     emit(StateScopeEvent.ValueChanged(5))
                 }
-
-                // Return current state
-                state
             }
 
             // Update action handling
@@ -154,7 +150,6 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
         state<StateScopeState.Final> {
             enter {
                 emit(StateScopeEvent.Completed)
-                state
             }
         }
     }
@@ -189,8 +184,6 @@ private fun createCancellationTestStore(
                         onBackgroundTaskCancel()
                     }
                 }
-
-                state
             }
 
             action<StateScopeAction.Stop> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -118,7 +118,7 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
         // Initial state handling
         state<StateScopeState.Initial> {
             action<StateScopeAction.Start> {
-                StateScopeState.Running()
+                state.update(StateScopeState.Running())
             }
         }
 
@@ -137,12 +137,12 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
 
             // Update action handling
             action<StateScopeAction.Update> {
-                StateScopeState.Running(action.newValue)
+                state.update(StateScopeState.Running(action.newValue))
             }
 
             // Stop action transitions to Final
             action<StateScopeAction.Stop> {
-                StateScopeState.Final
+                state.update(StateScopeState.Final)
             }
         }
 
@@ -165,7 +165,7 @@ private fun createCancellationTestStore(
 
         state<StateScopeState.Initial> {
             action<StateScopeAction.Start> {
-                StateScopeState.Running()
+                state.update(StateScopeState.Running())
             }
         }
 
@@ -187,7 +187,7 @@ private fun createCancellationTestStore(
             }
 
             action<StateScopeAction.Stop> {
-                StateScopeState.Final
+                state.update(StateScopeState.Final)
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -371,7 +371,7 @@ private fun createTodoStore(
         // Global error handling
         state<TodoState> {
             error {
-                TodoState.Error(error.message ?: "Unknown error")
+                state.update(TodoState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -299,7 +299,7 @@ private fun createTodoStore(
         state<TodoState.Loading> {
             enter {
                 val todos = repository.loadTodos()
-                TodoState.Loaded(todos)
+                state.update(TodoState.Loaded(todos))
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -291,7 +291,7 @@ private fun createTodoStore(
         // Idle state handling
         state<TodoState.Idle> {
             action<TodoAction.LoadTodos> {
-                TodoState.Loading
+                state.update(TodoState.Loading)
             }
         }
 
@@ -312,59 +312,57 @@ private fun createTodoStore(
                     completed = false,
                 )
                 val savedTodo = repository.addTodo(newTodo)
-                state.copy(todos = state.todos + savedTodo)
+                state.update(state.copy(todos = state.todos + savedTodo))
             }
 
             action<TodoAction.ToggleCompletion> {
                 val todoToUpdate = state.todos.first { it.id == action.todoId }
                 val updatedTodo = todoToUpdate.copy(completed = !todoToUpdate.completed)
                 val savedTodo = repository.updateTodo(updatedTodo)
-                state.copy(
+                state.update(state.copy(
                     todos = state.todos.map {
                         if (it.id == action.todoId) savedTodo else it
                     },
-                )
+                ))
             }
 
             action<TodoAction.DeleteTodo> {
                 val success = repository.deleteTodo(action.todoId)
                 if (success) {
-                    state.copy(todos = state.todos.filter { it.id != action.todoId })
-                } else {
-                    state
+                    state.update(state.copy(todos = state.todos.filter { it.id != action.todoId }))
                 }
             }
 
             action<TodoAction.StartEditing> {
                 val todoToEdit = state.todos.first { it.id == action.todoId }
-                TodoState.Editing(todoToEdit, state.todos)
+                state.update(TodoState.Editing(todoToEdit, state.todos))
             }
         }
 
         // Editing state handling
         state<TodoState.Editing> {
             action<TodoAction.UpdateEditingTitle> {
-                state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle))
+                state.update(state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle)))
             }
 
             action<TodoAction.SaveEdit> {
                 val updatedTodo = repository.updateTodo(state.editingTodo)
-                TodoState.Loaded(
+                state.update(TodoState.Loaded(
                     state.allTodos.map {
                         if (it.id == updatedTodo.id) updatedTodo else it
                     },
-                )
+                ))
             }
 
             action<TodoAction.CancelEdit> {
-                TodoState.Loaded(state.allTodos)
+                state.update(TodoState.Loaded(state.allTodos))
             }
         }
 
         // Error state handling
         state<TodoState.Error> {
             action<TodoAction.RetryFromError> {
-                TodoState.Idle
+                state.update(TodoState.Idle)
             }
         }
 


### PR DESCRIPTION
## Summary
- Refactors EnterContext, ErrorContext, and ActionContext interfaces to use a consistent state.update() pattern
- Replaces direct state return with state.update() method calls in all context types
- Updates all test files to follow the new pattern

🤖 Generated with [Claude Code](https://claude.ai/code)