### PR TITLE
Remove unused generic type parameters

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/Middleware.kt
@@ -11,7 +11,7 @@ interface Middleware<S : State, A : Action, E : Event> {
      *
      * @param middlewareContext The context providing access to store functionality
      */
-    suspend fun onInit(middlewareContext: MiddlewareContext<S, A, E>) {}
+    suspend fun onInit(middlewareContext: MiddlewareContext<A>) {}
 
     /**
      * Called before an action is dispatched.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareContext.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/MiddlewareContext.kt
@@ -6,7 +6,7 @@ import kotlin.coroutines.CoroutineContext
  * Context available in middleware components.
  * Provides access to action dispatch and coroutine context for middleware operations.
  */
-interface MiddlewareContext<S : State, A : Action, E : Event> {
+interface MiddlewareContext<A : Action> {
     /**
      * Dispatches an action from middleware.
      * Use this to trigger new state transitions from within middleware.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -55,9 +55,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val onAction: suspend ActionScope<S, A, E, S>.() -> Unit
 
-    protected abstract val onExit: suspend ExitScope<S, A, E>.() -> Unit
+    protected abstract val onExit: suspend ExitScope<S, E>.() -> Unit
 
-    protected abstract val onError: suspend ErrorScope<S, A, E, S>.() -> Unit
+    protected abstract val onError: suspend ErrorScope<S, E, S>.() -> Unit
 
     private val coroutineScope by lazy {
         CoroutineScope(
@@ -103,7 +103,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             mutex.withLock {
                 processMiddleware {
                     onInit(
-                        object : MiddlewareContext<S, A, E> {
+                        object : MiddlewareContext<A> {
                             override fun dispatch(action: A) {
                                 this@StoreImpl.dispatch(action)
                             }
@@ -264,7 +264,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         try {
             processMiddleware { beforeStateExit(state) }
             onExit.invoke(
-                object : ExitScope<S, A, E> {
+                object : ExitScope<S, E> {
                     override val state = state
                     override suspend fun event(event: E) {
                         emit(event)
@@ -293,7 +293,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         processMiddleware { beforeError(state, throwable) }
         var newState: S? = null
         onError.invoke(
-            object : ErrorScope<S, A, E, S> {
+            object : ErrorScope<S, E, S> {
                 override val state = state
                 override val error = throwable
                 override suspend fun event(event: E) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -59,7 +59,7 @@ interface EnterScope<S : State, A : Action, E : Event, S0 : State> : StoreScope 
  * Scope available when a state is being exited.
  * Used in exit handlers to perform cleanup or side effects when leaving a state.
  */
-interface ExitScope<S : State, A : Action, E : Event> : StoreScope {
+interface ExitScope<S : State, E : Event> : StoreScope {
     /**
      * The current state that's being exited
      */
@@ -110,7 +110,7 @@ interface ActionScope<S : State, A : Action, E : Event, S0 : State> : StoreScope
  * Scope available when an error occurs in a state handler.
  * Used in error handlers to recover from errors or update state accordingly.
  */
-interface ErrorScope<S : State, A : Action, E : Event, S0 : State> : StoreScope {
+interface ErrorScope<S : State, E : Event, S0 : State> : StoreScope {
     /**
      * The current state when the error occurred
      */

--- a/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
+++ b/tart-logging/src/commonMain/kotlin/io/yumemi/tart/logging/LoggingMiddleware.kt
@@ -30,7 +30,7 @@ open class LoggingMiddleware<S : State, A : Action, E : Event>(
 ) : Middleware<S, A, E> {
     private lateinit var coroutineScope: CoroutineScope
 
-    override suspend fun onInit(middlewareContext: MiddlewareContext<S, A, E>) {
+    override suspend fun onInit(middlewareContext: MiddlewareContext<A>) {
         this.coroutineScope = CoroutineScope(middlewareContext.coroutineContext + SupervisorJob() + coroutineDispatcher)
     }
 

--- a/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
+++ b/tart-message/src/commonMain/kotlin/io/yumemi/tart/message/MessageMiddleware.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.launch
  */
 @Suppress("unused")
 class MessageMiddleware<S : State, A : Action, E : Event>(
-    private val receive: suspend MiddlewareContext<S, A, E>.(Message) -> Unit,
+    private val receive: suspend MiddlewareContext<A>.(Message) -> Unit,
 ) : Middleware<S, A, E> {
-    override suspend fun onInit(middlewareContext: MiddlewareContext<S, A, E>) {
+    override suspend fun onInit(middlewareContext: MiddlewareContext<A>) {
         CoroutineScope(middlewareContext.coroutineContext).launch {
             MessageHub.messages.collect {
                 receive.invoke(middlewareContext, it)


### PR DESCRIPTION
## Summary
- Removed unused generic type parameters from MiddlewareContext, ExitScope and ErrorScope interfaces
- Simplified API by removing unnecessary type parameters
- Updated all related implementations to maintain compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)