### PR TITLE
Add isActive property to LaunchScope interface

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -232,6 +232,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     stateScope.launch(coroutineDispatcher) {
                         try {
                             val launchScope = object : EnterScope.LaunchScope<A, E> {
+                                override val isActive: Boolean get() = stateScope.isActive
                                 override fun dispatch(action: A) {
                                     if (stateScope.isActive) {
                                         this@StoreImpl.dispatch(action)

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -54,6 +54,14 @@ interface EnterScope<S : State, A : Action, E : Event, S0 : State> : StoreScope 
     @TartStoreDsl
     interface LaunchScope<A : Action, E : Event> : StoreScope {
         /**
+         * Checks if the coroutine scope is still active.
+         * Use this to verify if the state is still active before performing operations.
+         *
+         * @return True if the scope is still active, false otherwise
+         */
+        val isActive: Boolean
+
+        /**
          * Dispatches an action to the store.
          * @param action The action to dispatch
          */


### PR DESCRIPTION
## Summary
- Added isActive property to LaunchScope interface to improve scope management and provide explicit activity status checking

## Test plan
- Existing tests should pass

🤖 Generated with [Claude Code](https://claude.ai/code)