### PR TITLE
Add type support for error handling in Tart store framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ If you prepare a *State* for error display and handle the error in the `enter{}`
 ```kt
 sealed interface CounterState : State {
     // ...
-    data class Error(val error: Throwable) : CounterState
+    data class Error(val error: Exception) : CounterState
 }
 ```
 
@@ -288,7 +288,7 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
             state(CounterState.Main(count = count))
         }
 
-        error {
+        error<Exception> { // specify the type of error you want to catch
             // you can also branch using the error type if necessary
             state(CounterState.Error(error = error))
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-tart = "3.0.0-alpha01"
+tart = "3.0.0-alpha02"
 agp = "8.6.1"
 kotlin = "2.1.10"
 coroutines = "1.10.1"

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -58,7 +58,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val onExit: suspend ExitScope<S, E>.() -> Unit
 
-    protected abstract val onError: suspend ErrorScope<S, E, S>.() -> Unit
+    protected abstract val onError: suspend ErrorScope<S, E, S, Throwable>.() -> Unit
 
     private val coroutineScope by lazy {
         CoroutineScope(
@@ -301,7 +301,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         processMiddleware { beforeError(state, throwable) }
         var newState: S? = null
         onError.invoke(
-            object : ErrorScope<S, E, S> {
+            object : ErrorScope<S, E, S, Throwable> {
                 override val state = state
                 override val error = throwable
                 override suspend fun event(event: E) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -14,11 +14,11 @@ sealed interface StoreScope
  * Used in enter handlers to manage state transitions and side effects.
  */
 @TartStoreDsl
-interface EnterScope<S : State, A : Action, E : Event, S0 : State> : StoreScope {
+interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     /**
      * The current state that's being entered
      */
-    val state: S
+    val state: S2
 
     /**
      * Emits an event from the enter handler.
@@ -44,7 +44,7 @@ interface EnterScope<S : State, A : Action, E : Event, S0 : State> : StoreScope 
      *
      * @param state The new state value to update to
      */
-    fun state(state: S0)
+    fun state(state: S)
 
     /**
      * Scope available inside launch blocks.
@@ -102,11 +102,11 @@ interface ExitScope<S : State, E : Event> : StoreScope {
  * Used in action handlers to update state based on an action.
  */
 @TartStoreDsl
-interface ActionScope<S : State, A : Action, E : Event, S0 : State> : StoreScope {
+interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     /**
      * The current state when the action is being processed
      */
-    val state: S
+    val state: S2
 
     /**
      * The action being processed
@@ -127,7 +127,7 @@ interface ActionScope<S : State, A : Action, E : Event, S0 : State> : StoreScope
      *
      * @param state The new state value to update to
      */
-    fun state(state: S0)
+    fun state(state: S)
 }
 
 /**
@@ -135,16 +135,16 @@ interface ActionScope<S : State, A : Action, E : Event, S0 : State> : StoreScope
  * Used in error handlers to recover from errors or update state accordingly.
  */
 @TartStoreDsl
-interface ErrorScope<S : State, E : Event, S0 : State> : StoreScope {
+interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     /**
      * The current state when the error occurred
      */
-    val state: S
+    val state: S2
 
     /**
      * The error that occurred
      */
-    val error: Throwable
+    val error: T
 
     /**
      * Emits an event from the error handler.
@@ -160,5 +160,5 @@ interface ErrorScope<S : State, E : Event, S0 : State> : StoreScope {
      *
      * @param state The new state value to update to
      */
-    fun state(state: S0)
+    fun state(state: S)
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -232,7 +232,7 @@ private fun createCounterStore(
             action<CounterAction.ForceError> {
                 throw RuntimeException(action.message)
             }
-            error {
+            error<Exception> {
                 event(CounterEvent.ErrorOccurred(error.message ?: "Unknown error"))
                 state(CounterState.Error(error.message ?: "Unknown error"))
             }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -169,7 +169,7 @@ private fun createLoginStore(
         }
         // Error handling for all states
         state<LoginState> {
-            error {
+            error<Exception> {
                 state(LoginState.Error(error.message ?: "Unknown error"))
             }
         }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -372,7 +372,7 @@ private fun createTodoStore(
 
         // Global error handling
         state<TodoState> {
-            error {
+            error<Exception> {
                 state(TodoState.Error(error.message ?: "Unknown error"))
             }
         }


### PR DESCRIPTION
## Summary
- Add type support for error handlers to provide better compile-time safety
- Improved generic type parameters for error handling in StoreScope interfaces
- Updated test cases to use the new typed error approach

🤖 Generated with [Claude Code](https://claude.ai/code)