### PR TITLE
Rename newState() and newStateBy() to nextState() and nextStateBy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 ```
 
 Define how the *State* is changed by *Action* by using the `state{}` and `action{}` blocks.
-Specify the resulting *State* using the `newState()` specification.
-If no `newState()` is specified, the current state remains unchanged.
-For complex state updates with conditional logic, you can use `newStateBy{}` with a block that computes and returns the new state.
+Specify the resulting *State* using the `nextState()` specification.
+If no `nextState()` is specified, the current state remains unchanged.
+For complex state updates with conditional logic, you can use `nextStateBy{}` with a block that computes and returns the new state.
 
 ```kt
 val store: Store<CounterState, CounterAction, CounterEvent> = Store(CounterState(count = 0)) {
@@ -68,12 +68,12 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store(CounterState
     state<CounterState> {
 
         action<CounterAction.Increment> {
-            newState(state.copy(count = state.count + 1))
+            nextState(state.copy(count = state.count + 1))
         }
         
         action<CounterAction.Decrement> {
             if (0 < state.count) {
-                newState(state.copy(count = state.count - 1))
+                nextState(state.copy(count = state.count - 1))
             } else {
                 // do not change State
             }
@@ -267,9 +267,9 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
         enter {
             try {
                 val count = counterRepository.get()
-                newState(CounterState.Main(count = count))
+                nextState(CounterState.Main(count = count))
             } catch (t: Throwable) {
-                newState(CounterState.Error(error = t))
+                nextState(CounterState.Error(error = t))
             }
         }
     }
@@ -287,20 +287,20 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
         enter {
             // no error handling code
             val count = counterRepository.get()
-            newState(CounterState.Main(count = count))
+            nextState(CounterState.Main(count = count))
         }
 
         // more specific exceptions should be placed first
         error<IllegalStateException> {
             // ...
-            newState(CounterState.Error(error = error))
+            nextState(CounterState.Error(error = error))
         }
         
         // more general exception handlers should come last
         // you can also catch just 'Exception' and branch based on the type of the error property inside the block
         error<Exception> { // catches any remaining exceptions
             // ...
-            newState(CounterState.Error(error = error))
+            nextState(CounterState.Error(error = error))
         }
     }
 }

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -205,11 +205,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     emit(event)
                 }
 
-                override fun newState(state: S) {
+                override fun nextState(state: S) {
                     newState = state
                 }
                 
-                override fun newStateBy(block: () -> S) {
+                override fun nextStateBy(block: () -> S) {
                     newState = block()
                 }
             },
@@ -262,11 +262,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     }
                 }
 
-                override fun newState(state: S) {
+                override fun nextState(state: S) {
                     newState = state
                 }
                 
-                override fun newStateBy(block: () -> S) {
+                override fun nextStateBy(block: () -> S) {
                     newState = block()
                 }
             },
@@ -316,11 +316,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     emit(event)
                 }
 
-                override fun newState(state: S) {
+                override fun nextState(state: S) {
                     newState = state
                 }
                 
-                override fun newStateBy(block: () -> S) {
+                override fun nextStateBy(block: () -> S) {
                     newState = block()
                 }
             },

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -44,7 +44,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      *
      * @param state The new state value to update to
      */
-    fun newState(state: S)
+    fun nextState(state: S)
     
     /**
      * Updates the current state with a new state value computed from the given block.
@@ -52,7 +52,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      *
      * @param block A function that computes and returns the new state
      */
-    fun newStateBy(block: () -> S)
+    fun nextStateBy(block: () -> S)
 
     /**
      * Scope available inside launch blocks.
@@ -135,7 +135,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      *
      * @param state The new state value to update to
      */
-    fun newState(state: S)
+    fun nextState(state: S)
     
     /**
      * Updates the current state with a new state value computed from the given block.
@@ -143,7 +143,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      *
      * @param block A function that computes and returns the new state
      */
-    fun newStateBy(block: () -> S)
+    fun nextStateBy(block: () -> S)
 }
 
 /**
@@ -176,7 +176,7 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
      *
      * @param state The new state value to update to
      */
-    fun newState(state: S)
+    fun nextState(state: S)
     
     /**
      * Updates the current state with a new state value computed from the given block.
@@ -184,5 +184,5 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
      *
      * @param block A function that computes and returns the new state
      */
-    fun newStateBy(block: () -> S)
+    fun nextStateBy(block: () -> S)
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -181,7 +181,7 @@ private fun createCounterStore(
         // Initial state handling
         state<CounterState.Initial> {
             action<CounterAction.Start> {
-                newState(CounterState.Active(0))
+                nextState(CounterState.Active(0))
             }
         }
 
@@ -201,29 +201,29 @@ private fun createCounterStore(
                     event(CounterEvent.ThresholdReached(10))
                 }
 
-                newState(state.copy(count = newCount))
+                nextState(state.copy(count = newCount))
             }
 
             action<CounterAction.Decrement> {
                 val newCount = state.count - 1
                 event(CounterEvent.CountChanged(newCount))
-                newState(state.copy(count = newCount))
+                nextState(state.copy(count = newCount))
             }
 
             action<CounterAction.Reset> {
                 event(CounterEvent.CountChanged(0))
-                newState(state.copy(count = 0))
+                nextState(state.copy(count = 0))
             }
 
             action<CounterAction.Pause> {
-                newState(CounterState.Paused(state.count))
+                nextState(CounterState.Paused(state.count))
             }
         }
 
         // Paused state handling
         state<CounterState.Paused> {
             action<CounterAction.Resume> {
-                newState(CounterState.Active(state.count))
+                nextState(CounterState.Active(state.count))
             }
         }
 
@@ -234,7 +234,7 @@ private fun createCounterStore(
             }
             error<Exception> {
                 event(CounterEvent.ErrorOccurred(error.message ?: "Unknown error"))
-                newState(CounterState.Error(error.message ?: "Unknown error"))
+                nextState(CounterState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
@@ -125,7 +125,7 @@ private fun createFlowCollectStore(
         // Initial state handling
         state<FlowState.Initial> {
             action<FlowAction.StartCollecting> {
-                newState(FlowState.Active(0)) // Start with a default value before flow collection
+                nextState(FlowState.Active(0)) // Start with a default value before flow collection
             }
         }
 
@@ -143,11 +143,11 @@ private fun createFlowCollectStore(
 
             action<FlowAction.UpdateValue> {
                 // Update state with the latest value from flow
-                newState(state.copy(value = action.value))
+                nextState(state.copy(value = action.value))
             }
 
             action<FlowAction.Complete> {
-                newState(FlowState.Completed)
+                nextState(FlowState.Completed)
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -143,7 +143,7 @@ private fun createLoginStore(
                 // Validate input values
                 val isValidInput = action.username.isNotBlank() && action.password.isNotBlank()
 
-                newStateBy {
+                nextStateBy {
                     if (isValidInput) {
                         // For valid input, transition to loading state
                         LoginState.Loading(action.username, action.password)
@@ -164,13 +164,13 @@ private fun createLoginStore(
                     // Process for successful login
                     event(LoginEvent.NavigateToHome(state.username))
 
-                    newStateBy {
+                    nextStateBy {
                         // Transition to success state
                         LoginState.Success(state.username)
                     }
                 } else {
                     // Process for failed login
-                    newStateBy {
+                    nextStateBy {
                         // Transition to error state
                         LoginState.Error("Authentication failed")
                     }
@@ -180,13 +180,13 @@ private fun createLoginStore(
         // Processing for Error state
         state<LoginState.Error> {
             action<LoginAction.RetryFromError> {
-                newState(LoginState.Initial)
+                nextState(LoginState.Initial)
             }
         }
         // Error handling for all states
         state<LoginState> {
             error<Exception> {
-                newState(LoginState.Error(error.message ?: "Unknown error"))
+                nextState(LoginState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ServiceWrapperUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ServiceWrapperUseCaseTest.kt
@@ -127,7 +127,7 @@ private fun createTestStore(
 
         state<CounterServiceState.Idle> {
             action<CounterServiceAction.Start> {
-                newState(CounterServiceState.Running(count = 0))
+                nextState(CounterServiceState.Running(count = 0))
             }
         }
 
@@ -141,11 +141,11 @@ private fun createTestStore(
             }
 
             action<CounterServiceAction.UpdateCount> {
-                newState(CounterServiceState.Running(count = action.count))
+                nextState(CounterServiceState.Running(count = action.count))
             }
 
             action<CounterServiceAction.Stop> {
-                newState(CounterServiceState.Idle)
+                nextState(CounterServiceState.Idle)
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -62,15 +62,15 @@ private fun createTestStore(
         coroutineContext(Dispatchers.Unconfined)
         state<BaseState.Loading> {
             enter {
-                newState(BaseState.Main(count = 0))
+                nextState(BaseState.Main(count = 0))
             }
         }
         state<BaseState.Main> {
             action<BaseAction.Increment> {
-                newState(state.copy(count = state.count + 1))
+                nextState(state.copy(count = state.count + 1))
             }
             action<BaseAction.Decrement> {
-                newState(state.copy(count = state.count - 1))
+                nextState(state.copy(count = state.count - 1))
             }
             action<BaseAction.EmitEvent> {
                 event(BaseEvent.CountUpdated(state.count))

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreSaverTest.kt
@@ -45,7 +45,7 @@ private fun createTestStore(
         stateSaver(stateSaver)
         state<SaverState> {
             action<SaverAction.Update> {
-                newState(state.copy(value = action.value))
+                nextState(state.copy(value = action.value))
             }
         }
     }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -118,7 +118,7 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
         // Initial state handling
         state<StateScopeState.Initial> {
             action<StateScopeAction.Start> {
-                newState(StateScopeState.Running())
+                nextState(StateScopeState.Running())
             }
         }
 
@@ -137,12 +137,12 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
 
             // Update action handling
             action<StateScopeAction.Update> {
-                newState(StateScopeState.Running(action.newValue))
+                nextState(StateScopeState.Running(action.newValue))
             }
 
             // Stop action transitions to Final
             action<StateScopeAction.Stop> {
-                newState(StateScopeState.Final)
+                nextState(StateScopeState.Final)
             }
         }
 
@@ -165,7 +165,7 @@ private fun createCancellationTestStore(
 
         state<StateScopeState.Initial> {
             action<StateScopeAction.Start> {
-                newState(StateScopeState.Running())
+                nextState(StateScopeState.Running())
             }
         }
 
@@ -187,7 +187,7 @@ private fun createCancellationTestStore(
             }
 
             action<StateScopeAction.Stop> {
-                newState(StateScopeState.Final)
+                nextState(StateScopeState.Final)
             }
         }
 

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -291,7 +291,7 @@ private fun createTodoStore(
         // Idle state handling
         state<TodoState.Idle> {
             action<TodoAction.LoadTodos> {
-                newState(TodoState.Loading)
+                nextState(TodoState.Loading)
             }
         }
 
@@ -299,7 +299,7 @@ private fun createTodoStore(
         state<TodoState.Loading> {
             enter {
                 val todos = repository.loadTodos()
-                newState(TodoState.Loaded(todos))
+                nextState(TodoState.Loaded(todos))
             }
         }
 
@@ -312,7 +312,7 @@ private fun createTodoStore(
                     completed = false,
                 )
                 val savedTodo = repository.addTodo(newTodo)
-                newState(state.copy(todos = state.todos + savedTodo))
+                nextState(state.copy(todos = state.todos + savedTodo))
             }
 
             action<TodoAction.ToggleCompletion> {
@@ -320,7 +320,7 @@ private fun createTodoStore(
                 val updatedTodo = todoToUpdate.copy(completed = !todoToUpdate.completed)
                 val savedTodo = repository.updateTodo(updatedTodo)
                 
-                newStateBy {
+                nextStateBy {
                     // Create updated todo list
                     val updatedTodoList = state.todos.map {
                         if (it.id == action.todoId) savedTodo else it
@@ -333,27 +333,27 @@ private fun createTodoStore(
             action<TodoAction.DeleteTodo> {
                 val success = repository.deleteTodo(action.todoId)
                 if (success) {
-                    newState(state.copy(todos = state.todos.filter { it.id != action.todoId }))
+                    nextState(state.copy(todos = state.todos.filter { it.id != action.todoId }))
                 }
             }
 
             action<TodoAction.StartEditing> {
                 val todoToEdit = state.todos.first { it.id == action.todoId }
-                newState(TodoState.Editing(todoToEdit, state.todos))
+                nextState(TodoState.Editing(todoToEdit, state.todos))
             }
         }
 
         // Editing state handling
         state<TodoState.Editing> {
             action<TodoAction.UpdateEditingTitle> {
-                newState(state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle)))
+                nextState(state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle)))
             }
 
             action<TodoAction.SaveEdit> {
                 // Save edited content to repository
                 val savedTodo = repository.updateTodo(state.editingTodo)
                 
-                newStateBy {
+                nextStateBy {
                     // Create updated todo list with the edited task
                     val updatedTodoList = state.allTodos.map {
                         if (it.id == savedTodo.id) savedTodo else it
@@ -365,21 +365,21 @@ private fun createTodoStore(
             }
 
             action<TodoAction.CancelEdit> {
-                newState(TodoState.Loaded(state.allTodos))
+                nextState(TodoState.Loaded(state.allTodos))
             }
         }
 
         // Error state handling
         state<TodoState.Error> {
             action<TodoAction.RetryFromError> {
-                newState(TodoState.Idle)
+                nextState(TodoState.Idle)
             }
         }
 
         // Global error handling
         state<TodoState> {
             error<Exception> {
-                newState(TodoState.Error(error.message ?: "Unknown error"))
+                nextState(TodoState.Error(error.message ?: "Unknown error"))
             }
         }
     }

--- a/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
+++ b/tart-logging/src/commonTest/kotlin/io/yumemi/tart/logging/LoggingMiddlewareTest.kt
@@ -55,10 +55,10 @@ private fun createTestStore(
         middleware(middleware)
         state<CounterState> {
             action<CounterAction.Increment> {
-                newState(state.copy(count = state.count + 1))
+                nextState(state.copy(count = state.count + 1))
             }
             action<CounterAction.Decrement> {
-                newState(state.copy(count = state.count - 1))
+                nextState(state.copy(count = state.count - 1))
             }
         }
     }


### PR DESCRIPTION
## Summary
- Changed method names to make state management more intuitive
- `newState()` → `nextState()` and `newStateBy()` → `nextStateBy()`
- Updated all implementations, tests, and documentation

## Test plan
- All existing tests have been updated and pass successfully
- No behavior changes, only method name changes

🤖 Generated with [Claude Code](https://claude.ai/code)