### PR TITLE
Add transaction scope for atomic state updates

### DIFF
--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/EventStreamUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/EventStreamUseCaseTest.kt
@@ -1,0 +1,256 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * This test case was generated with assistance from Anthropic's Claude AI.
+ */
+
+// State Transition Diagram:
+//
+// ┌─────────────────────────────┐
+// │     ┌───────────────┐       │
+// │     │               │       │
+// │     ▼               │       │
+// │    Idle ────────► Active    │
+// │     ▲              │  ▲     │
+// │     │              │  │     │
+// │     │              ▼  │     │
+// │     └───────────── Error    │
+// │                             │
+// │           Active            │
+// │             │               │
+// │             ▼               │
+// │   ┌─────────────────────┐   │
+// │   │                     │   │
+// │   │  Processing Events  │   │
+// │   │                     │   │
+// │   └─────────────────────┘   │
+// │                             │
+// └─────────────────────────────┘
+//
+// Idle: Initial state or unsubscribed state, no active subscription
+// Active: Actively subscribed to events and processing them
+// Error: Error occurred during event processing
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class EventStreamUseCaseTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun eventStream_shouldSubscribeAndProcessEvents() = runTest(testDispatcher) {
+        // Mock implementation of event provider
+        val mockEventProvider = MockEventProvider()
+        val eventStreamMonitor = EventStreamMonitor(mockEventProvider)
+
+        // Create store with idle state
+        val store = createTestStore(eventStreamMonitor)
+
+        // Initial state should be Idle
+        assertIs<EventStreamState.Idle>(store.currentState)
+
+        // Start subscription - goes directly to Active state
+        store.dispatch(EventStreamAction.Subscribe)
+
+        // State should change directly to Active
+        assertIs<EventStreamState.Active>(store.currentState)
+
+        // Simulate receiving first event
+        val firstEvent = DataEvent("first-data", 1234567890L) // Fixed timestamp for test
+        mockEventProvider.emitEvent(firstEvent)
+
+        // State should update with the processed data
+        val stateAfterFirstEvent = store.currentState
+        assertIs<EventStreamState.Active>(stateAfterFirstEvent)
+        assertEquals(firstEvent.data, stateAfterFirstEvent.lastProcessedData)
+
+        // Simulate receiving second event - should continue to process in Active state
+        val secondEvent = DataEvent("second-data", 1234567891L) // Fixed timestamp for test
+        mockEventProvider.emitEvent(secondEvent)
+
+        // State should update again with the new data
+        val stateAfterSecondEvent = store.currentState
+        assertIs<EventStreamState.Active>(stateAfterSecondEvent)
+        assertEquals(secondEvent.data, stateAfterSecondEvent.lastProcessedData)
+
+        // Unsubscribe
+        store.dispatch(EventStreamAction.Unsubscribe)
+
+        // State should return to Idle
+        assertIs<EventStreamState.Idle>(store.currentState)
+    }
+
+    @Test
+    fun eventStream_shouldHandleProcessingErrors() = runTest(testDispatcher) {
+        // Mock implementation of event provider
+        val mockEventProvider = MockEventProvider()
+        val eventStreamMonitor = EventStreamMonitor(mockEventProvider)
+
+        // Create store with idle state
+        val store = createTestStore(eventStreamMonitor)
+
+        // Start subscription - goes directly to Active state
+        store.dispatch(EventStreamAction.Subscribe)
+
+        // State should change directly to Active
+        assertIs<EventStreamState.Active>(store.currentState)
+
+        // Simulate error event
+        val error = Exception("Processing error")
+        mockEventProvider.emitError(error)
+
+        // State should change to Error
+        val currentState = store.currentState
+        assertIs<EventStreamState.Error>(currentState)
+        assertEquals(error, currentState.error)
+    }
+}
+
+// Domain models
+private data class DataEvent(
+    val data: String,
+    val timestamp: Long,
+)
+
+// Event provider interfaces
+private interface EventProvider {
+    fun registerCallback(
+        onEvent: (DataEvent) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): RegistrationHandle
+
+    interface RegistrationHandle {
+        fun unregister()
+    }
+}
+
+// Mock implementation for testing
+private class MockEventProvider : EventProvider {
+    private var onEvent: ((DataEvent) -> Unit)? = null
+    private var onError: ((Throwable) -> Unit)? = null
+    private var isRegistered = false
+
+    private val registrationHandle = object : EventProvider.RegistrationHandle {
+        override fun unregister() {
+            isRegistered = false
+            onEvent = null
+            onError = null
+        }
+    }
+
+    override fun registerCallback(
+        onEvent: (DataEvent) -> Unit,
+        onError: (Throwable) -> Unit,
+    ): EventProvider.RegistrationHandle {
+        this.onEvent = onEvent
+        this.onError = onError
+        isRegistered = true
+        return registrationHandle
+    }
+
+    fun emitEvent(event: DataEvent) {
+        if (isRegistered) {
+            onEvent?.invoke(event)
+        }
+    }
+
+    fun emitError(error: Throwable) {
+        if (isRegistered) {
+            onError?.invoke(error)
+        }
+    }
+}
+
+// Monitor class that wraps callback-based API with Flow
+private class EventStreamMonitor(private val eventProvider: EventProvider) {
+
+    val eventStream: Flow<Result<DataEvent>> = callbackFlow {
+        val handle = eventProvider.registerCallback(
+            onEvent = { event ->
+                trySend(Result.success(event))
+            },
+            onError = { error ->
+                trySend(Result.failure(error))
+            },
+        )
+
+        awaitClose {
+            handle.unregister()
+        }
+    }
+}
+
+// Tart State definitions
+private sealed interface EventStreamState : State {
+    data object Idle : EventStreamState
+    data class Active(val lastProcessedData: String? = null) : EventStreamState
+    data class Error(val error: Throwable) : EventStreamState
+}
+
+// Tart Action definitions
+private sealed interface EventStreamAction : Action {
+    data object Subscribe : EventStreamAction
+    data object Unsubscribe : EventStreamAction
+}
+
+private fun createTestStore(
+    eventStreamMonitor: EventStreamMonitor,
+): Store<EventStreamState, EventStreamAction, Nothing> {
+    return Store {
+        initialState(EventStreamState.Idle)
+        coroutineContext(Dispatchers.Unconfined)
+
+        state<EventStreamState.Idle> {
+            action<EventStreamAction.Subscribe> {
+                // Direct transition to Active state
+                nextState(EventStreamState.Active())
+            }
+        }
+
+        state<EventStreamState.Active> {
+            enter {
+                // Collect events from the stream
+                launch {
+                    eventStreamMonitor.eventStream.collect { result ->
+                        result.fold(
+                            onSuccess = { event ->
+                                transaction {
+                                    // Update state with new data while staying in Active state
+                                    nextState(EventStreamState.Active(lastProcessedData = event.data))
+                                }
+                            },
+                            onFailure = { error ->
+                                transaction {
+                                    nextState(EventStreamState.Error(error))
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+
+            action<EventStreamAction.Unsubscribe> {
+                nextState(EventStreamState.Idle)
+            }
+        }
+
+        state<EventStreamState.Error> {
+            action<EventStreamAction.Subscribe> {
+                nextState(EventStreamState.Active())
+            }
+
+            action<EventStreamAction.Unsubscribe> {
+                nextState(EventStreamState.Idle)
+            }
+        }
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/FlowCollectUseCaseTest.kt
@@ -108,7 +108,6 @@ private sealed interface FlowState : State {
 // Action definitions
 private sealed interface FlowAction : Action {
     data object StartCollecting : FlowAction
-    data class UpdateValue(val value: Int) : FlowAction
     data object Complete : FlowAction
 }
 
@@ -135,15 +134,11 @@ private fun createFlowCollectStore(
                 // Use launch to collect the flow
                 launch {
                     dataFlow.collect { value ->
-                        // Dispatch action to update state with the new value
-                        dispatch(FlowAction.UpdateValue(value))
+                        transaction {
+                            nextStateBy { state.copy(value = value) }
+                        }
                     }
                 }
-            }
-
-            action<FlowAction.UpdateValue> {
-                // Update state with the latest value from flow
-                nextState(state.copy(value = action.value))
             }
 
             action<FlowAction.Complete> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ServiceWrapperUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/ServiceWrapperUseCaseTest.kt
@@ -114,7 +114,6 @@ private sealed interface CounterServiceState : State {
 
 private sealed interface CounterServiceAction : Action {
     data object Start : CounterServiceAction
-    data class UpdateCount(val count: Int) : CounterServiceAction
     data object Stop : CounterServiceAction
 }
 
@@ -135,13 +134,11 @@ private fun createTestStore(
             enter {
                 launch {
                     myServiceMonitor.count.collect {
-                        dispatch(CounterServiceAction.UpdateCount(it))
+                        transaction {
+                            nextState(state.copy(count = it))
+                        }
                     }
                 }
-            }
-
-            action<CounterServiceAction.UpdateCount> {
-                nextState(CounterServiceState.Running(count = action.count))
             }
 
             action<CounterServiceAction.Stop> {

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -100,7 +100,6 @@ private sealed interface StateScopeState : State {
 private sealed interface StateScopeAction : Action {
     data object Start : StateScopeAction
     data object Stop : StateScopeAction
-    data class Update(val newValue: Int) : StateScopeAction
 }
 
 // Event definitions
@@ -127,17 +126,13 @@ private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateSc
             enter {
                 // Launch background task with launch function
                 launch {
-                    // Update state via action
-                    dispatch(StateScopeAction.Update(5))
+                    transaction {
+                        nextState(state.copy(value = 5))
+                    }
 
                     // Emit event
                     event(StateScopeEvent.ValueChanged(5))
                 }
-            }
-
-            // Update action handling
-            action<StateScopeAction.Update> {
-                nextState(StateScopeState.Running(action.newValue))
             }
 
             // Stop action transitions to Final

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/WebSocketUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/WebSocketUseCaseTest.kt
@@ -1,0 +1,310 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * This test case was generated with assistance from Anthropic's Claude AI.
+ */
+
+// State Transition Diagram:
+//
+// ┌───────────────────────────────────────────────────┐
+// │                                                   │
+// │            Disconnected       Error               │
+// │                 ▲               ▲                 │
+// │                 │               │                 │
+// │                 │   ┌───────────┘                 │
+// │                 │   │                             │
+// │                 ▼   ▼                             │
+// │  ┌─────────────────────────────────────────────┐  │
+// │  │              Connected                      │  │
+// │  │                                             │  │
+// │  │   Status: Connecting/Connected/Disconnected │  │
+// │  │   Messages: Received real-time updates      │  │
+// │  │                                             │  │
+// │  └─────────────────────────────────────────────┘  │
+// │                                                   │
+// └───────────────────────────────────────────────────┘
+//
+// Disconnected: Initial state, no connection to WebSocket server
+// Connected: Managing WebSocket connection with different internal statuses
+// Error: Error state for handling connection failures
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class WebSocketUseCaseTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun webSocket_shouldConnectAndHandleMessages() = runTest(testDispatcher) {
+        // Mock implementation of WebSocket service
+        val mockWebSocket = MockWebSocketService()
+
+        // Create store with disconnected state
+        val store = createTestStore(mockWebSocket)
+
+        // Initial state should be Disconnected
+        assertIs<WebSocketState.Disconnected>(store.currentState)
+
+        // Connect to WebSocket
+        store.dispatch(WebSocketAction.Connect)
+
+        // State should change to Connected with CONNECTING status
+        val connectingState = store.currentState
+        assertIs<WebSocketState.Connected>(connectingState)
+        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+
+        // Simulate connection success
+        mockWebSocket.simulateConnectionEstablished()
+
+        // State should change to Connected with CONNECTED status
+        val connectedState = store.currentState
+        assertIs<WebSocketState.Connected>(connectedState)
+        assertEquals(WebSocketState.ConnectionStatus.CONNECTED, connectedState.connectionStatus)
+
+        // Simulate receiving a message
+        val testMessage = WebSocketMessage("test-id", "Test message", 1234567890L) // Using fixed timestamp for test
+        mockWebSocket.simulateMessageReceived(testMessage)
+
+        // State should update with the latest message
+        val stateWithMessage = store.currentState
+        assertIs<WebSocketState.Connected>(stateWithMessage)
+        assertEquals(testMessage, stateWithMessage.latestMessage)
+        assertEquals(WebSocketState.ConnectionStatus.CONNECTED, stateWithMessage.connectionStatus)
+
+        // Disconnect
+        store.dispatch(WebSocketAction.Disconnect)
+
+        // State should first change to DISCONNECTING
+        val disconnectingState = store.currentState
+        assertIs<WebSocketState.Connected>(disconnectingState)
+        assertEquals(WebSocketState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
+
+        // After the disconnect event is processed, state should return to Disconnected
+        mockWebSocket.simulateConnectionClosed()
+
+        // State should return to Disconnected
+        assertIs<WebSocketState.Disconnected>(store.currentState)
+    }
+
+    @Test
+    fun webSocket_shouldHandleConnectionFailures() = runTest(testDispatcher) {
+        // Mock implementation of WebSocket service
+        val mockWebSocket = MockWebSocketService()
+
+        // Create store with disconnected state
+        val store = createTestStore(mockWebSocket)
+
+        // Connect to WebSocket
+        store.dispatch(WebSocketAction.Connect)
+
+        // Verify we're in CONNECTING status
+        val connectingState = store.currentState
+        assertIs<WebSocketState.Connected>(connectingState)
+        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+
+        // Simulate connection failure
+        val error = Exception("Connection refused")
+        mockWebSocket.simulateConnectionError(error)
+
+        // State should change to Error
+        val errorState = store.currentState
+        assertIs<WebSocketState.Error>(errorState)
+        assertEquals(error, errorState.error)
+    }
+
+    @Test
+    fun webSocket_shouldHandleDisconnectDuringConnecting() = runTest(testDispatcher) {
+        // Mock implementation of WebSocket service
+        val mockWebSocket = MockWebSocketService()
+
+        // Create store with disconnected state
+        val store = createTestStore(mockWebSocket)
+
+        // Connect to WebSocket
+        store.dispatch(WebSocketAction.Connect)
+
+        // Verify we're in CONNECTING status
+        val connectingState = store.currentState
+        assertIs<WebSocketState.Connected>(connectingState)
+        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+
+        // Disconnect while still connecting
+        store.dispatch(WebSocketAction.Disconnect)
+
+        // State should first change to DISCONNECTING
+        val disconnectingState = store.currentState
+        assertIs<WebSocketState.Connected>(disconnectingState)
+        assertEquals(WebSocketState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
+
+        // After the disconnect event is processed, state should return to Disconnected
+        mockWebSocket.simulateConnectionClosed()
+
+        assertIs<WebSocketState.Disconnected>(store.currentState)
+    }
+}
+
+// Domain models
+private data class WebSocketMessage(
+    val id: String,
+    val content: String,
+    val timestamp: Long,
+)
+
+// WebSocket service interfaces
+private interface WebSocketService {
+    fun connect()
+    fun disconnect()
+    val connectionEvents: Flow<ConnectionEvent>
+    val messages: Flow<WebSocketMessage>
+
+    sealed interface ConnectionEvent {
+        data object Connected : ConnectionEvent
+        data object Disconnected : ConnectionEvent
+        data class Error(val throwable: Throwable) : ConnectionEvent
+    }
+}
+
+// Mock implementation for testing
+private class MockWebSocketService : WebSocketService {
+    private val connectionChannel = Channel<WebSocketService.ConnectionEvent>(Channel.BUFFERED)
+    private val messageChannel = Channel<WebSocketMessage>(Channel.BUFFERED)
+
+    override val connectionEvents: Flow<WebSocketService.ConnectionEvent> = connectionChannel.receiveAsFlow()
+    override val messages: Flow<WebSocketMessage> = messageChannel.receiveAsFlow()
+
+    override fun connect() {
+        // Connection logic happens in simulation methods for testing
+    }
+
+    override fun disconnect() {
+        // In real implementation, this would trigger the actual disconnect
+        // The event itself is sent by simulateConnectionClosed() for testing
+    }
+
+    fun simulateConnectionEstablished() {
+        connectionChannel.trySend(WebSocketService.ConnectionEvent.Connected)
+    }
+
+    fun simulateConnectionError(error: Throwable) {
+        connectionChannel.trySend(WebSocketService.ConnectionEvent.Error(error))
+    }
+
+    fun simulateConnectionClosed() {
+        connectionChannel.trySend(WebSocketService.ConnectionEvent.Disconnected)
+    }
+
+    fun simulateMessageReceived(message: WebSocketMessage) {
+        messageChannel.trySend(message)
+    }
+}
+
+// Tart State definitions
+private sealed interface WebSocketState : State {
+    data object Disconnected : WebSocketState
+
+    data class Connected(
+        val connectionStatus: ConnectionStatus = ConnectionStatus.CONNECTING,
+        val latestMessage: WebSocketMessage? = null,
+    ) : WebSocketState
+
+    data class Error(val error: Throwable) : WebSocketState
+
+    enum class ConnectionStatus {
+        CONNECTING, CONNECTED, DISCONNECTING
+    }
+}
+
+// Tart Action definitions
+private sealed interface WebSocketAction : Action {
+    data object Connect : WebSocketAction
+    data object Disconnect : WebSocketAction
+}
+
+private fun createTestStore(
+    webSocketService: WebSocketService,
+): Store<WebSocketState, WebSocketAction, Nothing> {
+    return Store {
+        initialState(WebSocketState.Disconnected)
+        coroutineContext(Dispatchers.Unconfined)
+
+        state<WebSocketState.Disconnected> {
+            action<WebSocketAction.Connect> {
+                nextState(WebSocketState.Connected(connectionStatus = WebSocketState.ConnectionStatus.CONNECTING))
+            }
+        }
+
+        state<WebSocketState.Connected> {
+            enter {
+                // Skip if not in CONNECTING status (early return pattern)
+                if (state.connectionStatus != WebSocketState.ConnectionStatus.CONNECTING) {
+                    return@enter
+                }
+
+                // Initiate connection
+                webSocketService.connect()
+
+                // Monitor both connection events and messages in a single state
+                launch {
+                    webSocketService.connectionEvents.collect { event ->
+                        when (event) {
+                            is WebSocketService.ConnectionEvent.Connected -> {
+                                transaction {
+                                    nextState(state.copy(connectionStatus = WebSocketState.ConnectionStatus.CONNECTED))
+                                }
+                            }
+
+                            is WebSocketService.ConnectionEvent.Error -> {
+                                transaction {
+                                    nextState(WebSocketState.Error(event.throwable))
+                                }
+                            }
+
+                            is WebSocketService.ConnectionEvent.Disconnected -> {
+                                transaction {
+                                    nextState(WebSocketState.Disconnected)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                launch {
+                    webSocketService.messages.collect { message ->
+                        transaction {
+                            // Only update messages if in CONNECTED status
+                            if (state.connectionStatus == WebSocketState.ConnectionStatus.CONNECTED) {
+                                nextState(state.copy(latestMessage = message))
+                            }
+                            // Otherwise ignore messages that arrive before fully connected
+                            // or after disconnecting has started
+                        }
+                    }
+                }
+            }
+
+            action<WebSocketAction.Disconnect> {
+                // First update state to disconnecting
+                nextState(state.copy(connectionStatus = WebSocketState.ConnectionStatus.DISCONNECTING))
+
+                // Then initiate disconnect
+                webSocketService.disconnect()
+                // Actual state change to Disconnected will happen through the event flow
+            }
+        }
+
+        state<WebSocketState.Error> {
+            action<WebSocketAction.Connect> {
+                nextState(WebSocketState.Connected(connectionStatus = WebSocketState.ConnectionStatus.CONNECTING))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add transaction scope functionality to allow atomic state updates from event streams
- Add comprehensive WebSocket example test case demonstrating transaction usage

## Test plan
- New WebSocketUseCaseTest demonstrates full functionality
- All existing tests pass with updated naming

🤖 Generated with [Claude Code](https://claude.ai/code)