### PR TITLE
Make transaction method suspend and wait for completion

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -272,8 +272,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                 emit(event)
                             }
 
-                            override fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
-                                coroutineScope.launch(coroutineDispatcher) {
+                            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
+                                val job = coroutineScope.launch(coroutineDispatcher) {
                                     mutex.withLock {
                                         if (stateScope.isActive) {
                                             var newStateInBlock: S? = null
@@ -304,6 +304,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                         }
                                     }
                                 }
+                                job.join()
                             }
                         }
                         try {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -82,7 +82,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
          * @param coroutineDispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
          * @param block The suspending block of code to execute as a transaction
          */
-        fun transaction(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, E, S2>.() -> Unit)
+        suspend fun transaction(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, E, S2>.() -> Unit)
 
         /**
          * Scope available within a transaction operation.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreBaseTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -15,6 +16,9 @@ class StoreBaseTest {
     @Test
     fun tartStore_shouldHandleActions() = runTest(testDispatcher) {
         val store = createTestStore(BaseState.Loading)
+
+        // Store is not started
+        assertIs<BaseState.Loading>(store.currentState)
 
         store.dispatch(BaseAction.Increment)
         store.dispatch(BaseAction.Increment)


### PR DESCRIPTION
## Summary
- Changed  method to be suspend function
- Added job.join() to wait for transaction completion

🤖 Generated with [Claude Code](https://claude.ai/code)