### PR TITLE
Standardize test store creation function names

### DIFF
--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/CounterUseCaseTest.kt
@@ -37,205 +37,205 @@ class CounterUseCaseTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    // State definitions
+    sealed interface AppState : State {
+        data object Initial : AppState
+        data class Active(val count: Int) : AppState
+        data class Paused(val count: Int) : AppState
+        data class Error(val message: String) : AppState
+    }
+
+    // Action definitions
+    sealed interface AppAction : Action {
+        data object Start : AppAction
+        data object Increment : AppAction
+        data object Decrement : AppAction
+        data object Reset : AppAction
+        data object Pause : AppAction
+        data object Resume : AppAction
+        data class ForceError(val message: String) : AppAction
+    }
+
+    // Event definitions
+    sealed interface AppEvent : Event {
+        data class CountChanged(val newCount: Int) : AppEvent
+        data class ThresholdReached(val threshold: Int) : AppEvent
+        data class ErrorOccurred(val message: String) : AppEvent
+    }
+
+    private fun createTestStore(
+        initialState: AppState = AppState.Initial,
+    ): Store<AppState, AppAction, AppEvent> {
+        return Store(initialState) {
+            // Configure coroutine context for tests
+            coroutineContext(Dispatchers.Unconfined)
+
+            // Initial state handling
+            state<AppState.Initial> {
+                action<AppAction.Start> {
+                    nextState(AppState.Active(0))
+                }
+            }
+
+            // Active state handling
+            state<AppState.Active> {
+                enter {
+                    // Optional initialization when entering active state
+                    event(AppEvent.CountChanged(state.count))
+                }
+
+                action<AppAction.Increment> {
+                    val newCount = state.count + 1
+                    event(AppEvent.CountChanged(newCount))
+
+                    // Emit threshold event if count reaches certain value
+                    if (newCount == 10) {
+                        event(AppEvent.ThresholdReached(10))
+                    }
+
+                    nextState(state.copy(count = newCount))
+                }
+
+                action<AppAction.Decrement> {
+                    val newCount = state.count - 1
+                    event(AppEvent.CountChanged(newCount))
+                    nextState(state.copy(count = newCount))
+                }
+
+                action<AppAction.Reset> {
+                    event(AppEvent.CountChanged(0))
+                    nextState(state.copy(count = 0))
+                }
+
+                action<AppAction.Pause> {
+                    nextState(AppState.Paused(state.count))
+                }
+            }
+
+            // Paused state handling
+            state<AppState.Paused> {
+                action<AppAction.Resume> {
+                    nextState(AppState.Active(state.count))
+                }
+            }
+
+            // Global error handling
+            state<AppState> {
+                action<AppAction.ForceError> {
+                    throw RuntimeException(action.message)
+                }
+                error<Exception> {
+                    event(AppEvent.ErrorOccurred(error.message ?: "Unknown error"))
+                    nextState(AppState.Error(error.message ?: "Unknown error"))
+                }
+            }
+        }
+    }
+
     @Test
     fun counter_initialState() = runTest(testDispatcher) {
-        val store = createCounterStore()
-        assertEquals(CounterState.Initial, store.currentState)
+        val store = createTestStore()
+        assertEquals(AppState.Initial, store.currentState)
     }
 
     @Test
     fun counter_startShouldTransitionToActive() = runTest(testDispatcher) {
-        val store = createCounterStore()
+        val store = createTestStore()
 
-        store.dispatch(CounterAction.Start)
+        store.dispatch(AppAction.Start)
 
-        assertTrue(store.currentState is CounterState.Active)
-        assertEquals(0, (store.currentState as CounterState.Active).count)
+        assertTrue(store.currentState is AppState.Active)
+        assertEquals(0, (store.currentState as AppState.Active).count)
     }
 
     @Test
     fun counter_incrementAction() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(0))
+        val store = createTestStore(AppState.Active(0))
 
-        store.dispatch(CounterAction.Increment)
+        store.dispatch(AppAction.Increment)
 
-        assertEquals(CounterState.Active(1), store.currentState)
+        assertEquals(AppState.Active(1), store.currentState)
     }
 
     @Test
     fun counter_decrementAction() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(5))
+        val store = createTestStore(AppState.Active(5))
 
-        store.dispatch(CounterAction.Decrement)
+        store.dispatch(AppAction.Decrement)
 
-        assertEquals(CounterState.Active(4), store.currentState)
+        assertEquals(AppState.Active(4), store.currentState)
     }
 
     @Test
     fun counter_resetAction() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(10))
+        val store = createTestStore(AppState.Active(10))
 
-        store.dispatch(CounterAction.Reset)
+        store.dispatch(AppAction.Reset)
 
-        assertEquals(CounterState.Active(0), store.currentState)
+        assertEquals(AppState.Active(0), store.currentState)
     }
 
     @Test
     fun counter_pauseAction() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(3))
+        val store = createTestStore(AppState.Active(3))
 
-        store.dispatch(CounterAction.Pause)
+        store.dispatch(AppAction.Pause)
 
-        assertTrue(store.currentState is CounterState.Paused)
-        assertEquals(3, (store.currentState as CounterState.Paused).count)
+        assertTrue(store.currentState is AppState.Paused)
+        assertEquals(3, (store.currentState as AppState.Paused).count)
     }
 
     @Test
     fun counter_resumeAction() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Paused(7))
+        val store = createTestStore(AppState.Paused(7))
 
-        store.dispatch(CounterAction.Resume)
+        store.dispatch(AppAction.Resume)
 
-        assertTrue(store.currentState is CounterState.Active)
-        assertEquals(7, (store.currentState as CounterState.Active).count)
+        assertTrue(store.currentState is AppState.Active)
+        assertEquals(7, (store.currentState as AppState.Active).count)
     }
 
     @Test
     fun counter_errorHandling() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(0))
+        val store = createTestStore(AppState.Active(0))
 
         // Force an error by dispatching a special action
-        store.dispatch(CounterAction.ForceError("Test error"))
+        store.dispatch(AppAction.ForceError("Test error"))
 
-        assertTrue(store.currentState is CounterState.Error)
-        assertEquals("Test error", (store.currentState as CounterState.Error).message)
+        assertTrue(store.currentState is AppState.Error)
+        assertEquals("Test error", (store.currentState as AppState.Error).message)
     }
 
     @Test
     fun counter_eventEmission() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(5))
+        val store = createTestStore(AppState.Active(5))
 
-        var capturedEvent: CounterEvent? = null
+        var capturedEvent: AppEvent? = null
         store.collectEvent { event ->
             capturedEvent = event
         }
 
-        store.dispatch(CounterAction.Increment)
+        store.dispatch(AppAction.Increment)
 
         assertNotNull(capturedEvent)
-        assertTrue(capturedEvent is CounterEvent.CountChanged)
-        assertEquals(6, (capturedEvent as CounterEvent.CountChanged).newCount)
+        assertTrue(capturedEvent is AppEvent.CountChanged)
+        assertEquals(6, (capturedEvent as AppEvent.CountChanged).newCount)
     }
 
     @Test
     fun counter_thresholdReached() = runTest(testDispatcher) {
-        val store = createCounterStore(CounterState.Active(9))
+        val store = createTestStore(AppState.Active(9))
 
-        var thresholdEvent: CounterEvent.ThresholdReached? = null
+        var thresholdEvent: AppEvent.ThresholdReached? = null
         store.collectEvent { event ->
-            if (event is CounterEvent.ThresholdReached) {
+            if (event is AppEvent.ThresholdReached) {
                 thresholdEvent = event
             }
         }
 
-        store.dispatch(CounterAction.Increment) // This should reach 10
+        store.dispatch(AppAction.Increment) // This should reach 10
 
         assertNotNull(thresholdEvent)
         assertEquals(10, thresholdEvent?.threshold)
-    }
-}
-
-// State definitions
-private sealed interface CounterState : State {
-    data object Initial : CounterState
-    data class Active(val count: Int) : CounterState
-    data class Paused(val count: Int) : CounterState
-    data class Error(val message: String) : CounterState
-}
-
-// Action definitions
-private sealed interface CounterAction : Action {
-    data object Start : CounterAction
-    data object Increment : CounterAction
-    data object Decrement : CounterAction
-    data object Reset : CounterAction
-    data object Pause : CounterAction
-    data object Resume : CounterAction
-    data class ForceError(val message: String) : CounterAction
-}
-
-// Event definitions
-private sealed interface CounterEvent : Event {
-    data class CountChanged(val newCount: Int) : CounterEvent
-    data class ThresholdReached(val threshold: Int) : CounterEvent
-    data class ErrorOccurred(val message: String) : CounterEvent
-}
-
-private fun createCounterStore(
-    initialState: CounterState = CounterState.Initial,
-): Store<CounterState, CounterAction, CounterEvent> {
-    return Store(initialState) {
-        // Configure coroutine context for tests
-        coroutineContext(Dispatchers.Unconfined)
-
-        // Initial state handling
-        state<CounterState.Initial> {
-            action<CounterAction.Start> {
-                nextState(CounterState.Active(0))
-            }
-        }
-
-        // Active state handling
-        state<CounterState.Active> {
-            enter {
-                // Optional initialization when entering active state
-                event(CounterEvent.CountChanged(state.count))
-            }
-
-            action<CounterAction.Increment> {
-                val newCount = state.count + 1
-                event(CounterEvent.CountChanged(newCount))
-
-                // Emit threshold event if count reaches certain value
-                if (newCount == 10) {
-                    event(CounterEvent.ThresholdReached(10))
-                }
-
-                nextState(state.copy(count = newCount))
-            }
-
-            action<CounterAction.Decrement> {
-                val newCount = state.count - 1
-                event(CounterEvent.CountChanged(newCount))
-                nextState(state.copy(count = newCount))
-            }
-
-            action<CounterAction.Reset> {
-                event(CounterEvent.CountChanged(0))
-                nextState(state.copy(count = 0))
-            }
-
-            action<CounterAction.Pause> {
-                nextState(CounterState.Paused(state.count))
-            }
-        }
-
-        // Paused state handling
-        state<CounterState.Paused> {
-            action<CounterAction.Resume> {
-                nextState(CounterState.Active(state.count))
-            }
-        }
-
-        // Global error handling
-        state<CounterState> {
-            action<CounterAction.ForceError> {
-                throw RuntimeException(action.message)
-            }
-            error<Exception> {
-                event(CounterEvent.ErrorOccurred(error.message ?: "Unknown error"))
-                nextState(CounterState.Error(error.message ?: "Unknown error"))
-            }
-        }
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/LoginUseCaseTest.kt
@@ -34,21 +34,113 @@ class LoginUseCaseTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    // Login repository interface
+    interface LoginRepository {
+        suspend fun login(username: String, password: String): Boolean
+    }
+
+    // Mock repository implementation
+    class MockLoginRepository(var shouldSucceed: Boolean) : LoginRepository {
+        override suspend fun login(username: String, password: String): Boolean {
+            return shouldSucceed
+        }
+    }
+
+    // State definitions
+    sealed interface AppState : State {
+        data object Initial : AppState
+        data class Loading(val username: String, val password: String) : AppState
+        data class Success(val username: String) : AppState
+        data class Error(val message: String) : AppState
+    }
+
+    // Action definitions
+    sealed interface AppAction : Action {
+        data class Login(val username: String, val password: String) : AppAction
+        data object RetryFromError : AppAction
+    }
+
+    // Event definitions
+    sealed interface AppEvent : Event {
+        data class NavigateToHome(val username: String) : AppEvent
+    }
+
+    // Create a Store using the standard Store factory function
+    private fun createTestStore(
+        repository: LoginRepository,
+    ): Store<AppState, AppAction, AppEvent> {
+        return Store(AppState.Initial) {
+            coroutineContext(Dispatchers.Unconfined)
+            // Processing for Initial state
+            state<AppState.Initial> {
+                action<AppAction.Login> {
+                    // Validate input values
+                    val isValidInput = action.username.isNotBlank() && action.password.isNotBlank()
+
+                    nextStateBy {
+                        if (isValidInput) {
+                            // For valid input, transition to loading state
+                            AppState.Loading(action.username, action.password)
+                        } else {
+                            // For invalid input, transition to error state
+                            AppState.Error("Username and password must not be empty")
+                        }
+                    }
+                }
+            }
+            // Processing for Loading state
+            state<AppState.Loading> {
+                enter {
+                    // Execute login process in repository
+                    val loginSuccessful = repository.login(state.username, state.password)
+
+                    if (loginSuccessful) {
+                        // Process for successful login
+                        event(AppEvent.NavigateToHome(state.username))
+
+                        nextStateBy {
+                            // Transition to success state
+                            AppState.Success(state.username)
+                        }
+                    } else {
+                        // Process for failed login
+                        nextStateBy {
+                            // Transition to error state
+                            AppState.Error("Authentication failed")
+                        }
+                    }
+                }
+            }
+            // Processing for Error state
+            state<AppState.Error> {
+                action<AppAction.RetryFromError> {
+                    nextState(AppState.Initial)
+                }
+            }
+            // Error handling for all states
+            state<AppState> {
+                error<Exception> {
+                    nextState(AppState.Error(error.message ?: "Unknown error"))
+                }
+            }
+        }
+    }
+
     @Test
     fun loginFlow_successCase() = runTest(testDispatcher) {
         // Create Store with a repository that will succeed
         val repository = MockLoginRepository(shouldSucceed = true)
-        val store = createLoginStore(repository)
+        val store = createTestStore(repository)
 
         // Verify initial state
-        assertIs<LoginState.Initial>(store.currentState)
+        assertIs<AppState.Initial>(store.currentState)
 
         // Start login process
-        store.dispatch(LoginAction.Login("user123", "password123"))
+        store.dispatch(AppAction.Login("user123", "password123"))
 
         // Login successful, should be in Success state
-        assertIs<LoginState.Success>(store.currentState)
-        val successState = store.currentState as LoginState.Success
+        assertIs<AppState.Success>(store.currentState)
+        val successState = store.currentState as AppState.Success
         assertEquals("user123", successState.username)
     }
 
@@ -56,17 +148,17 @@ class LoginUseCaseTest {
     fun loginFlow_failureCase() = runTest(testDispatcher) {
         // Create Store with a repository that will fail
         val repository = MockLoginRepository(shouldSucceed = false)
-        val store = createLoginStore(repository)
+        val store = createTestStore(repository)
 
         // Verify initial state
-        assertIs<LoginState.Initial>(store.currentState)
+        assertIs<AppState.Initial>(store.currentState)
 
         // Start login process
-        store.dispatch(LoginAction.Login("user123", "wrong_password"))
+        store.dispatch(AppAction.Login("user123", "wrong_password"))
 
         // Login fails, should be in Error state
-        assertIs<LoginState.Error>(store.currentState)
-        val errorState = store.currentState as LoginState.Error
+        assertIs<AppState.Error>(store.currentState)
+        val errorState = store.currentState as AppState.Error
         assertEquals("Authentication failed", errorState.message)
     }
 
@@ -74,120 +166,28 @@ class LoginUseCaseTest {
     fun errorState_canRetryLogin() = runTest(testDispatcher) {
         // Create Store with a repository that will initially fail
         val repository = MockLoginRepository(shouldSucceed = false)
-        val store = createLoginStore(repository)
+        val store = createTestStore(repository)
 
         // Verify initial state
-        assertIs<LoginState.Initial>(store.currentState)
+        assertIs<AppState.Initial>(store.currentState)
 
         // First login attempt (will fail)
-        store.dispatch(LoginAction.Login("user123", "wrong_password"))
+        store.dispatch(AppAction.Login("user123", "wrong_password"))
 
         // Login fails, should be in Error state
-        assertIs<LoginState.Error>(store.currentState)
+        assertIs<AppState.Error>(store.currentState)
 
         // Change repository to succeed on next attempt
         repository.shouldSucceed = true
 
         // Send retry action
-        store.dispatch(LoginAction.RetryFromError)
-        assertIs<LoginState.Initial>(store.currentState)
+        store.dispatch(AppAction.RetryFromError)
+        assertIs<AppState.Initial>(store.currentState)
 
         // Try logging in again
-        store.dispatch(LoginAction.Login("user123", "correct_password"))
+        store.dispatch(AppAction.Login("user123", "correct_password"))
 
         // Login process is automatically handled by the enter block
-        assertIs<LoginState.Success>(store.currentState)
-    }
-}
-
-// State definitions
-private sealed interface LoginState : State {
-    data object Initial : LoginState
-    data class Loading(val username: String, val password: String) : LoginState
-    data class Success(val username: String) : LoginState
-    data class Error(val message: String) : LoginState
-}
-
-// Action definitions
-private sealed interface LoginAction : Action {
-    data class Login(val username: String, val password: String) : LoginAction
-    data object RetryFromError : LoginAction
-}
-
-// Event definitions
-private sealed interface LoginEvent : Event {
-    data class NavigateToHome(val username: String) : LoginEvent
-}
-
-// Login repository interface
-private interface LoginRepository {
-    suspend fun login(username: String, password: String): Boolean
-}
-
-// Mock repository implementation
-private class MockLoginRepository(var shouldSucceed: Boolean) : LoginRepository {
-    override suspend fun login(username: String, password: String): Boolean {
-        return shouldSucceed
-    }
-}
-
-// Create a Store using the standard Store factory function
-private fun createLoginStore(
-    repository: LoginRepository,
-): Store<LoginState, LoginAction, LoginEvent> {
-    return Store(LoginState.Initial) {
-        coroutineContext(Dispatchers.Unconfined)
-        // Processing for Initial state
-        state<LoginState.Initial> {
-            action<LoginAction.Login> {
-                // Validate input values
-                val isValidInput = action.username.isNotBlank() && action.password.isNotBlank()
-
-                nextStateBy {
-                    if (isValidInput) {
-                        // For valid input, transition to loading state
-                        LoginState.Loading(action.username, action.password)
-                    } else {
-                        // For invalid input, transition to error state
-                        LoginState.Error("Username and password must not be empty")
-                    }
-                }
-            }
-        }
-        // Processing for Loading state
-        state<LoginState.Loading> {
-            enter {
-                // Execute login process in repository
-                val loginSuccessful = repository.login(state.username, state.password)
-
-                if (loginSuccessful) {
-                    // Process for successful login
-                    event(LoginEvent.NavigateToHome(state.username))
-
-                    nextStateBy {
-                        // Transition to success state
-                        LoginState.Success(state.username)
-                    }
-                } else {
-                    // Process for failed login
-                    nextStateBy {
-                        // Transition to error state
-                        LoginState.Error("Authentication failed")
-                    }
-                }
-            }
-        }
-        // Processing for Error state
-        state<LoginState.Error> {
-            action<LoginAction.RetryFromError> {
-                nextState(LoginState.Initial)
-            }
-        }
-        // Error handling for all states
-        state<LoginState> {
-            error<Exception> {
-                nextState(LoginState.Error(error.message ?: "Unknown error"))
-            }
-        }
+        assertIs<AppState.Success>(store.currentState)
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreConcurrentTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreConcurrentTest.kt
@@ -17,17 +17,88 @@ class StoreConcurrentTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    sealed interface AppState : State {
+        data class Initial(val count: Int) : AppState
+        data class Processing(val count: Int) : AppState
+        data class Result(val count: Int) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object Increment : AppAction
+        data object Decrement : AppAction
+        data object DelayedIncrement : AppAction
+        data object RequestResult : AppAction
+    }
+
+    sealed interface AppEvent : Event {
+        data object Processing : AppEvent
+        data class Completed(val finalCount: Int) : AppEvent
+    }
+
+    private fun createTestStore(
+        initialState: AppState,
+    ): Store<AppState, AppAction, AppEvent> {
+        return Store(initialState) {
+            coroutineContext(Dispatchers.Unconfined)
+
+            state<AppState.Initial> {
+                action<AppAction.Increment> {
+                    nextState(AppState.Initial(state.count + 1))
+                }
+                action<AppAction.Decrement> {
+                    nextState(AppState.Initial(state.count - 1))
+                }
+                action<AppAction.DelayedIncrement> {
+                    nextState(AppState.Processing(state.count))
+                    event(AppEvent.Processing)
+                }
+                action<AppAction.RequestResult> {
+                    nextState(AppState.Result(state.count))
+                }
+            }
+
+            state<AppState.Processing> {
+                enter {
+                    launch {
+                        // Simulate long processing
+                        delay(100)
+                        transaction {
+                            val newCount = state.count + 1
+                            nextState(AppState.Result(newCount))
+                            event(AppEvent.Completed(newCount))
+                        }
+                    }
+                }
+
+                action<AppAction.RequestResult> {
+                    // This will wait for the transaction from enter to complete
+                    // due to mutex locking
+                    nextState(AppState.Result(state.count))
+                }
+            }
+
+            state<AppState.Result> {
+                action<AppAction.Increment> {
+                    nextState(AppState.Result(state.count + 1))
+                }
+                action<AppAction.Decrement> {
+                    nextState(AppState.Result(state.count - 1))
+                }
+            }
+        }
+    }
+
     @Test
     fun concurrentActions_shouldHandleRaceConditions() = runTest(testDispatcher) {
-        val store = createConcurrentTestStore(ConcurrentState.Initial(0))
+        val store = createTestStore(AppState.Initial(0))
 
         // Launch multiple concurrent actions
         val jobs = List(10) { index ->
             launch {
                 if (index % 2 == 0) {
-                    store.dispatch(ConcurrentAction.Increment)
+                    store.dispatch(AppAction.Increment)
                 } else {
-                    store.dispatch(ConcurrentAction.Decrement)
+                    store.dispatch(AppAction.Decrement)
                 }
             }
         }
@@ -36,32 +107,32 @@ class StoreConcurrentTest {
 
         // Verify final state of counter
         when (val finalState = store.currentState) {
-            is ConcurrentState.Initial -> assertEquals(0, finalState.count)
-            is ConcurrentState.Result -> assertEquals(0, finalState.count)
+            is AppState.Initial -> assertEquals(0, finalState.count)
+            is AppState.Result -> assertEquals(0, finalState.count)
             else -> throw AssertionError("Unexpected state type: ${finalState::class.simpleName}")
         }
     }
 
     @Test
     fun concurrentStateChanges_shouldPreserveMutexLocking() = runTest(testDispatcher) {
-        val store = createConcurrentTestStore(ConcurrentState.Initial(0))
+        val store = createTestStore(AppState.Initial(0))
 
         // Track emitted events to verify ordering
-        val events = mutableListOf<ConcurrentEvent>()
+        val events = mutableListOf<AppEvent>()
         store.collectEvent { event ->
             events.add(event)
         }
 
         // First action triggers a state change with a delay
         val delayedJob = launch {
-            store.dispatch(ConcurrentAction.DelayedIncrement)
+            store.dispatch(AppAction.DelayedIncrement)
         }
 
         // Give time for first dispatch to be processed
         kotlinx.coroutines.yield()
 
         // Second action should wait for the first to complete
-        store.dispatch(ConcurrentAction.RequestResult)
+        store.dispatch(AppAction.RequestResult)
 
         delayedJob.join()
 
@@ -70,82 +141,11 @@ class StoreConcurrentTest {
 
         // Verify event emission - we should at least have the Processing event
         assertEquals(1, events.size, "Should have at least the Processing event")
-        assertEquals(ConcurrentEvent.Processing, events[0])
+        assertEquals(AppEvent.Processing, events[0])
 
         // If the completed event was emitted, check its value
         if (events.size > 1) {
-            assertEquals(ConcurrentEvent.Completed(1), events[1])
-        }
-    }
-}
-
-private sealed interface ConcurrentState : State {
-    data class Initial(val count: Int) : ConcurrentState
-    data class Processing(val count: Int) : ConcurrentState
-    data class Result(val count: Int) : ConcurrentState
-}
-
-private sealed interface ConcurrentAction : Action {
-    data object Increment : ConcurrentAction
-    data object Decrement : ConcurrentAction
-    data object DelayedIncrement : ConcurrentAction
-    data object RequestResult : ConcurrentAction
-}
-
-private sealed interface ConcurrentEvent : Event {
-    data object Processing : ConcurrentEvent
-    data class Completed(val finalCount: Int) : ConcurrentEvent
-}
-
-private fun createConcurrentTestStore(
-    initialState: ConcurrentState,
-): Store<ConcurrentState, ConcurrentAction, ConcurrentEvent> {
-    return Store(initialState) {
-        coroutineContext(Dispatchers.Unconfined)
-
-        state<ConcurrentState.Initial> {
-            action<ConcurrentAction.Increment> {
-                nextState(ConcurrentState.Initial(state.count + 1))
-            }
-            action<ConcurrentAction.Decrement> {
-                nextState(ConcurrentState.Initial(state.count - 1))
-            }
-            action<ConcurrentAction.DelayedIncrement> {
-                nextState(ConcurrentState.Processing(state.count))
-                event(ConcurrentEvent.Processing)
-            }
-            action<ConcurrentAction.RequestResult> {
-                nextState(ConcurrentState.Result(state.count))
-            }
-        }
-
-        state<ConcurrentState.Processing> {
-            enter {
-                launch {
-                    // Simulate long processing
-                    delay(100)
-                    transaction {
-                        val newCount = state.count + 1
-                        nextState(ConcurrentState.Result(newCount))
-                        event(ConcurrentEvent.Completed(newCount))
-                    }
-                }
-            }
-
-            action<ConcurrentAction.RequestResult> {
-                // This will wait for the transaction from enter to complete
-                // due to mutex locking
-                nextState(ConcurrentState.Result(state.count))
-            }
-        }
-
-        state<ConcurrentState.Result> {
-            action<ConcurrentAction.Increment> {
-                nextState(ConcurrentState.Result(state.count + 1))
-            }
-            action<ConcurrentAction.Decrement> {
-                nextState(ConcurrentState.Result(state.count - 1))
-            }
+            assertEquals(AppEvent.Completed(1), events[1])
         }
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreExceptionTest.kt
@@ -11,12 +11,29 @@ class StoreExceptionTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    data class AppState(val value: Int) : State
+
+    private fun createTestStore(
+        initialState: AppState,
+        exceptionHandler: ExceptionHandler,
+    ): Store<AppState, Nothing, Nothing> {
+        return Store(initialState) {
+            this.coroutineContext(Dispatchers.Unconfined)
+            exceptionHandler(exceptionHandler)
+            state<AppState> {
+                enter {
+                    throw RuntimeException("error")
+                }
+            }
+        }
+    }
+
     @Test
     fun store_shouldUseExceptionHandlerOnError() = runTest(testDispatcher) {
         var handledException: Throwable? = null
 
         val store = createTestStore(
-            initialState = ExceptionState(0),
+            initialState = AppState(0),
             exceptionHandler = ExceptionHandler { error ->
                 handledException = error
             },
@@ -25,22 +42,5 @@ class StoreExceptionTest {
         store.state // access state to initialize the store
 
         assertNotNull(handledException)
-    }
-}
-
-private data class ExceptionState(val value: Int) : State
-
-private fun createTestStore(
-    initialState: ExceptionState,
-    exceptionHandler: ExceptionHandler,
-): Store<ExceptionState, Nothing, Nothing> {
-    return Store(initialState) {
-        this.coroutineContext(Dispatchers.Unconfined)
-        exceptionHandler(exceptionHandler)
-        state<ExceptionState> {
-            enter {
-                throw RuntimeException("error")
-            }
-        }
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -35,29 +35,110 @@ class StoreStateCoroutineScopeTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    // State definitions
+    sealed interface AppState : State {
+        data object Initial : AppState
+        data class Running(val value: Int = 0) : AppState
+        data object Final : AppState
+    }
+
+    // Action definitions
+    sealed interface AppAction : Action {
+        data object Start : AppAction
+        data object Stop : AppAction
+    }
+
+    // Event definitions
+    sealed interface AppEvent : Event {
+        data class ValueChanged(val value: Int) : AppEvent
+        data object Completed : AppEvent
+    }
+
+    // Store factory for basic functionality test
+    private fun createTestStore(
+        withCancellation: Boolean = false,
+        onBackgroundTaskStart: (() -> Unit)? = null,
+        onBackgroundTaskCancel: (() -> Unit)? = null,
+    ): Store<AppState, AppAction, AppEvent> {
+        return Store(AppState.Initial) {
+            // Configure to use Unconfined dispatcher
+            coroutineContext(Dispatchers.Unconfined)
+
+            // Initial state handling
+            state<AppState.Initial> {
+                action<AppAction.Start> {
+                    nextState(AppState.Running())
+                }
+            }
+
+            // Running state with background operations
+            state<AppState.Running> {
+                enter {
+                    // Launch background task with launch function
+                    launch {
+                        if (withCancellation) {
+                            try {
+                                onBackgroundTaskStart?.invoke()
+
+                                // Long-running task that should be cancelled
+                                delay(10000)
+
+                                // We shouldn't reach this
+                                throw IllegalStateException("Background task wasn't cancelled")
+                            } catch (e: Exception) {
+                                onBackgroundTaskCancel?.invoke()
+                            }
+                        } else {
+                            transaction {
+                                nextState(state.copy(value = 5))
+                            }
+
+                            // Emit event
+                            event(AppEvent.ValueChanged(5))
+                        }
+                    }
+                }
+
+                // Stop action transitions to Final
+                action<AppAction.Stop> {
+                    nextState(AppState.Final)
+                }
+            }
+
+            // Final state
+            state<AppState.Final> {
+                enter {
+                    if (!withCancellation) {
+                        event(AppEvent.Completed)
+                    }
+                }
+            }
+        }
+    }
+
     @Test
     fun enterCoroutineScope_dispatchesActionsAndEmitsEvents() = runTest(testDispatcher) {
         // Create store with test dispatcher
-        val store = createBasicStore()
+        val store = createTestStore()
 
         // Initial state check
-        assertEquals(StateScopeState.Initial, store.currentState)
+        assertEquals(AppState.Initial, store.currentState)
 
         // Transition to Running state
-        store.dispatch(StateScopeAction.Start)
+        store.dispatch(AppAction.Start)
 
         // Verify state transition occurred
-        assertTrue(store.currentState is StateScopeState.Running)
+        assertTrue(store.currentState is AppState.Running)
 
         // Verify background task updated state via action dispatch
-        val runningState = store.currentState as StateScopeState.Running
+        val runningState = store.currentState as AppState.Running
         assertEquals(5, runningState.value)
 
         // Move to final state
-        store.dispatch(StateScopeAction.Stop)
+        store.dispatch(AppAction.Stop)
 
         // Verify final state
-        assertEquals(StateScopeState.Final, store.currentState)
+        assertEquals(AppState.Final, store.currentState)
     }
 
     @Test
@@ -67,127 +148,25 @@ class StoreStateCoroutineScopeTest {
         var backgroundTaskCancelled = false
 
         // Create store with custom handling
-        val store = createCancellationTestStore(
+        val store = createTestStore(
+            withCancellation = true,
             onBackgroundTaskStart = { backgroundTaskRan = true },
             onBackgroundTaskCancel = { backgroundTaskCancelled = true },
         )
 
         // Start sequence
-        assertEquals(StateScopeState.Initial, store.currentState)
-        store.dispatch(StateScopeAction.Start)
-        assertEquals(StateScopeState.Running::class, store.currentState::class)
+        assertEquals(AppState.Initial, store.currentState)
+        store.dispatch(AppAction.Start)
+        assertEquals(AppState.Running::class, store.currentState::class)
 
         // Verify background task started
         assertTrue(backgroundTaskRan, "Background task should have started")
 
         // Immediately transition to final state
-        store.dispatch(StateScopeAction.Stop)
-        assertEquals(StateScopeState.Final, store.currentState)
+        store.dispatch(AppAction.Stop)
+        assertEquals(AppState.Final, store.currentState)
 
         // Verify background task was cancelled
         assertTrue(backgroundTaskCancelled, "Background task should have been cancelled")
-    }
-}
-
-// State definitions
-private sealed interface StateScopeState : State {
-    data object Initial : StateScopeState
-    data class Running(val value: Int = 0) : StateScopeState
-    data object Final : StateScopeState
-}
-
-// Action definitions
-private sealed interface StateScopeAction : Action {
-    data object Start : StateScopeAction
-    data object Stop : StateScopeAction
-}
-
-// Event definitions
-private sealed interface StateScopeEvent : Event {
-    data class ValueChanged(val value: Int) : StateScopeEvent
-    data object Completed : StateScopeEvent
-}
-
-// Store factory for basic functionality test
-private fun createBasicStore(): Store<StateScopeState, StateScopeAction, StateScopeEvent> {
-    return Store(StateScopeState.Initial) {
-        // Configure to use Unconfined dispatcher
-        coroutineContext(Dispatchers.Unconfined)
-
-        // Initial state handling
-        state<StateScopeState.Initial> {
-            action<StateScopeAction.Start> {
-                nextState(StateScopeState.Running())
-            }
-        }
-
-        // Running state with background operations
-        state<StateScopeState.Running> {
-            enter {
-                // Launch background task with launch function
-                launch {
-                    transaction {
-                        nextState(state.copy(value = 5))
-                    }
-
-                    // Emit event
-                    event(StateScopeEvent.ValueChanged(5))
-                }
-            }
-
-            // Stop action transitions to Final
-            action<StateScopeAction.Stop> {
-                nextState(StateScopeState.Final)
-            }
-        }
-
-        // Final state
-        state<StateScopeState.Final> {
-            enter {
-                event(StateScopeEvent.Completed)
-            }
-        }
-    }
-}
-
-// Store factory for cancellation test
-private fun createCancellationTestStore(
-    onBackgroundTaskStart: () -> Unit,
-    onBackgroundTaskCancel: () -> Unit,
-): Store<StateScopeState, StateScopeAction, StateScopeEvent> {
-    return Store(StateScopeState.Initial) {
-        coroutineContext(Dispatchers.Unconfined)
-
-        state<StateScopeState.Initial> {
-            action<StateScopeAction.Start> {
-                nextState(StateScopeState.Running())
-            }
-        }
-
-        state<StateScopeState.Running> {
-            enter {
-                launch {
-                    try {
-                        onBackgroundTaskStart()
-
-                        // Long-running task that should be cancelled
-                        delay(10000)
-
-                        // We shouldn't reach this
-                        throw IllegalStateException("Background task wasn't cancelled")
-                    } catch (e: Exception) {
-                        onBackgroundTaskCancel()
-                    }
-                }
-            }
-
-            action<StateScopeAction.Stop> {
-                nextState(StateScopeState.Final)
-            }
-        }
-
-        state<StateScopeState.Final> {
-            // Empty final state
-        }
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/TodoUseCaseTest.kt
@@ -39,46 +39,236 @@ class TodoUseCaseTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    // Todo item data class
+    data class Todo(
+        val id: String,
+        val title: String,
+        val completed: Boolean = false,
+    )
+
+    // Simple ID counter for tests
+    private var idCounter = 0
+
+    // Helper function to generate IDs in a platform-independent way
+    private fun generateId(): String {
+        val random = Random.nextInt(10000, 99999)
+        idCounter++
+        return "${abs(random)}_${idCounter}"
+    }
+
+    // Repository interface
+    interface TodoRepository {
+        suspend fun loadTodos(): List<Todo>
+        suspend fun addTodo(todo: Todo): Todo
+        suspend fun updateTodo(todo: Todo): Todo
+        suspend fun deleteTodo(todoId: String): Boolean
+    }
+
+    // Mock repository implementation
+    class MockTodoRepository(var shouldSucceed: Boolean) : TodoRepository {
+        val initialTodos = listOf(
+            Todo("1", "Complete project", false),
+            Todo("2", "Write tests", true),
+            Todo("3", "Review code", false),
+        )
+
+        private val _todos = initialTodos.toMutableList()
+
+        override suspend fun loadTodos(): List<Todo> {
+            if (!shouldSucceed) throw Exception("Failed to load todos")
+            return _todos.toList()
+        }
+
+        override suspend fun addTodo(todo: Todo): Todo {
+            if (!shouldSucceed) throw Exception("Failed to add todo")
+            _todos.add(todo)
+            return todo
+        }
+
+        override suspend fun updateTodo(todo: Todo): Todo {
+            if (!shouldSucceed) throw Exception("Failed to update todo")
+            val index = _todos.indexOfFirst { it.id == todo.id }
+            if (index >= 0) {
+                _todos[index] = todo
+            }
+            return todo
+        }
+
+        override suspend fun deleteTodo(todoId: String): Boolean {
+            if (!shouldSucceed) throw Exception("Failed to delete todo")
+            val initialSize = _todos.size
+            _todos.removeAll { it.id == todoId }
+            return _todos.size < initialSize
+        }
+    }
+
+    // State definitions
+    sealed interface AppState : State {
+        data object Idle : AppState
+        data object Loading : AppState
+        data class Loaded(val todos: List<Todo>) : AppState
+        data class Editing(val editingTodo: Todo, val allTodos: List<Todo>) : AppState
+        data class Error(val message: String) : AppState
+    }
+
+    // Action definitions
+    sealed interface AppAction : Action {
+        data object LoadTodos : AppAction
+        data class AddTodo(val title: String) : AppAction
+        data class ToggleCompletion(val todoId: String) : AppAction
+        data class DeleteTodo(val todoId: String) : AppAction
+        data class StartEditing(val todoId: String) : AppAction
+        data class UpdateEditingTitle(val newTitle: String) : AppAction
+        data object SaveEdit : AppAction
+        data object CancelEdit : AppAction
+        data object RetryFromError : AppAction
+    }
+
+    // Store factory
+    private fun createTestStore(
+        repository: TodoRepository = MockTodoRepository(true),
+        initialState: AppState = AppState.Idle,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(initialState) {
+            coroutineContext(Dispatchers.Unconfined)
+
+            // Idle state handling
+            state<AppState.Idle> {
+                action<AppAction.LoadTodos> {
+                    nextState(AppState.Loading)
+                }
+            }
+
+            // Loading state handling
+            state<AppState.Loading> {
+                enter {
+                    val todos = repository.loadTodos()
+                    nextState(AppState.Loaded(todos))
+                }
+            }
+
+            // Loaded state handling
+            state<AppState.Loaded> {
+                action<AppAction.AddTodo> {
+                    val newTodo = Todo(
+                        id = generateId(),
+                        title = action.title,
+                        completed = false,
+                    )
+                    val savedTodo = repository.addTodo(newTodo)
+                    nextState(state.copy(todos = state.todos + savedTodo))
+                }
+
+                action<AppAction.ToggleCompletion> {
+                    val todoToUpdate = state.todos.first { it.id == action.todoId }
+                    val updatedTodo = todoToUpdate.copy(completed = !todoToUpdate.completed)
+                    val savedTodo = repository.updateTodo(updatedTodo)
+
+                    nextStateBy {
+                        // Create updated todo list
+                        val updatedTodoList = state.todos.map {
+                            if (it.id == action.todoId) savedTodo else it
+                        }
+
+                        state.copy(todos = updatedTodoList)
+                    }
+                }
+
+                action<AppAction.DeleteTodo> {
+                    val success = repository.deleteTodo(action.todoId)
+                    if (success) {
+                        nextState(state.copy(todos = state.todos.filter { it.id != action.todoId }))
+                    }
+                }
+
+                action<AppAction.StartEditing> {
+                    val todoToEdit = state.todos.first { it.id == action.todoId }
+                    nextState(AppState.Editing(todoToEdit, state.todos))
+                }
+            }
+
+            // Editing state handling
+            state<AppState.Editing> {
+                action<AppAction.UpdateEditingTitle> {
+                    nextState(state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle)))
+                }
+
+                action<AppAction.SaveEdit> {
+                    // Save edited content to repository
+                    val savedTodo = repository.updateTodo(state.editingTodo)
+
+                    nextStateBy {
+                        // Create updated todo list with the edited task
+                        val updatedTodoList = state.allTodos.map {
+                            if (it.id == savedTodo.id) savedTodo else it
+                        }
+
+                        // Transition from editing state to loaded state
+                        AppState.Loaded(updatedTodoList)
+                    }
+                }
+
+                action<AppAction.CancelEdit> {
+                    nextState(AppState.Loaded(state.allTodos))
+                }
+            }
+
+            // Error state handling
+            state<AppState.Error> {
+                action<AppAction.RetryFromError> {
+                    nextState(AppState.Idle)
+                }
+            }
+
+            // Global error handling
+            state<AppState> {
+                error<Exception> {
+                    nextState(AppState.Error(error.message ?: "Unknown error"))
+                }
+            }
+        }
+    }
+
     @Test
     fun todoApp_initialState() = runTest(testDispatcher) {
-        val store = createTodoStore()
-        assertIs<TodoState.Idle>(store.currentState)
+        val store = createTestStore()
+        assertIs<AppState.Idle>(store.currentState)
     }
 
     @Test
     fun todoApp_loadTodosSuccess() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = true)
-        val store = createTodoStore(repository)
+        val store = createTestStore(repository)
 
-        store.dispatch(TodoAction.LoadTodos)
+        store.dispatch(AppAction.LoadTodos)
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         assertEquals(3, loadedState.todos.size)
     }
 
     @Test
     fun todoApp_loadTodosFailure() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = false)
-        val store = createTodoStore(repository)
+        val store = createTestStore(repository)
 
-        store.dispatch(TodoAction.LoadTodos)
+        store.dispatch(AppAction.LoadTodos)
 
-        assertIs<TodoState.Error>(store.currentState)
-        val errorState = store.currentState as TodoState.Error
+        assertIs<AppState.Error>(store.currentState)
+        val errorState = store.currentState as AppState.Error
         assertEquals("Failed to load todos", errorState.message)
     }
 
     @Test
     fun todoApp_addTodo() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = true)
-        val store = createTodoStore(repository, TodoState.Loaded(repository.initialTodos))
+        val store = createTestStore(repository, AppState.Loaded(repository.initialTodos))
 
-        val initialCount = (store.currentState as TodoState.Loaded).todos.size
-        store.dispatch(TodoAction.AddTodo("Buy groceries"))
+        val initialCount = (store.currentState as AppState.Loaded).todos.size
+        store.dispatch(AppAction.AddTodo("Buy groceries"))
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         assertEquals(initialCount + 1, loadedState.todos.size)
         assertEquals("Buy groceries", loadedState.todos.last().title)
         assertFalse(loadedState.todos.last().completed)
@@ -87,15 +277,15 @@ class TodoUseCaseTest {
     @Test
     fun todoApp_toggleTodoCompletion() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = true)
-        val store = createTodoStore(repository, TodoState.Loaded(repository.initialTodos))
+        val store = createTestStore(repository, AppState.Loaded(repository.initialTodos))
 
-        val todoToToggle = (store.currentState as TodoState.Loaded).todos.first()
+        val todoToToggle = (store.currentState as AppState.Loaded).todos.first()
         val initialCompletionStatus = todoToToggle.completed
 
-        store.dispatch(TodoAction.ToggleCompletion(todoToToggle.id))
+        store.dispatch(AppAction.ToggleCompletion(todoToToggle.id))
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         val updatedTodo = loadedState.todos.first { it.id == todoToToggle.id }
         assertEquals(!initialCompletionStatus, updatedTodo.completed)
     }
@@ -103,15 +293,15 @@ class TodoUseCaseTest {
     @Test
     fun todoApp_deleteTodo() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = true)
-        val store = createTodoStore(repository, TodoState.Loaded(repository.initialTodos))
+        val store = createTestStore(repository, AppState.Loaded(repository.initialTodos))
 
-        val todoToDelete = (store.currentState as TodoState.Loaded).todos.first()
-        val initialCount = (store.currentState as TodoState.Loaded).todos.size
+        val todoToDelete = (store.currentState as AppState.Loaded).todos.first()
+        val initialCount = (store.currentState as AppState.Loaded).todos.size
 
-        store.dispatch(TodoAction.DeleteTodo(todoToDelete.id))
+        store.dispatch(AppAction.DeleteTodo(todoToDelete.id))
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         assertEquals(initialCount - 1, loadedState.todos.size)
         assertFalse(loadedState.todos.any { it.id == todoToDelete.id })
     }
@@ -119,14 +309,14 @@ class TodoUseCaseTest {
     @Test
     fun todoApp_startEditingTodo() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = true)
-        val store = createTodoStore(repository, TodoState.Loaded(repository.initialTodos))
+        val store = createTestStore(repository, AppState.Loaded(repository.initialTodos))
 
-        val todoToEdit = (store.currentState as TodoState.Loaded).todos.first()
+        val todoToEdit = (store.currentState as AppState.Loaded).todos.first()
 
-        store.dispatch(TodoAction.StartEditing(todoToEdit.id))
+        store.dispatch(AppAction.StartEditing(todoToEdit.id))
 
-        assertIs<TodoState.Editing>(store.currentState)
-        val editingState = store.currentState as TodoState.Editing
+        assertIs<AppState.Editing>(store.currentState)
+        val editingState = store.currentState as AppState.Editing
         assertEquals(todoToEdit.id, editingState.editingTodo.id)
         assertEquals(todoToEdit.title, editingState.editingTodo.title)
     }
@@ -136,12 +326,12 @@ class TodoUseCaseTest {
         val repository = MockTodoRepository(shouldSucceed = true)
         val todoToEdit = repository.initialTodos.first()
         val editedTodo = todoToEdit.copy(title = "Updated task")
-        val store = createTodoStore(repository, TodoState.Editing(editedTodo, repository.initialTodos))
+        val store = createTestStore(repository, AppState.Editing(editedTodo, repository.initialTodos))
 
-        store.dispatch(TodoAction.SaveEdit)
+        store.dispatch(AppAction.SaveEdit)
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         val updatedTodo = loadedState.todos.first { it.id == todoToEdit.id }
         assertEquals("Updated task", updatedTodo.title)
     }
@@ -151,12 +341,12 @@ class TodoUseCaseTest {
         val repository = MockTodoRepository(shouldSucceed = true)
         val todoToEdit = repository.initialTodos.first()
         val editedTodo = todoToEdit.copy(title = "This edit will be discarded")
-        val store = createTodoStore(repository, TodoState.Editing(editedTodo, repository.initialTodos))
+        val store = createTestStore(repository, AppState.Editing(editedTodo, repository.initialTodos))
 
-        store.dispatch(TodoAction.CancelEdit)
+        store.dispatch(AppAction.CancelEdit)
 
-        assertIs<TodoState.Loaded>(store.currentState)
-        val loadedState = store.currentState as TodoState.Loaded
+        assertIs<AppState.Loaded>(store.currentState)
+        val loadedState = store.currentState as AppState.Loaded
         val unchangedTodo = loadedState.todos.first { it.id == todoToEdit.id }
         assertEquals(todoToEdit.title, unchangedTodo.title)
     }
@@ -164,223 +354,33 @@ class TodoUseCaseTest {
     @Test
     fun todoApp_errorRetry() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = false)
-        val store = createTodoStore(repository, TodoState.Error("Test error"))
+        val store = createTestStore(repository, AppState.Error("Test error"))
 
         // Change repository to succeed on retry
         repository.shouldSucceed = true
 
-        store.dispatch(TodoAction.RetryFromError)
+        store.dispatch(AppAction.RetryFromError)
 
         // Should be back to idle, ready to load
-        assertIs<TodoState.Idle>(store.currentState)
+        assertIs<AppState.Idle>(store.currentState)
 
         // Try loading again
-        store.dispatch(TodoAction.LoadTodos)
+        store.dispatch(AppAction.LoadTodos)
 
         // Should succeed this time
-        assertIs<TodoState.Loaded>(store.currentState)
+        assertIs<AppState.Loaded>(store.currentState)
     }
 
     @Test
     fun todoApp_errorHandling() = runTest(testDispatcher) {
         val repository = MockTodoRepository(shouldSucceed = false)
-        val store = createTodoStore(repository, TodoState.Loaded(repository.initialTodos))
+        val store = createTestStore(repository, AppState.Loaded(repository.initialTodos))
 
         // Force an error by trying to add a todo when repository is set to fail
-        store.dispatch(TodoAction.AddTodo("This will fail"))
+        store.dispatch(AppAction.AddTodo("This will fail"))
 
-        assertIs<TodoState.Error>(store.currentState)
-        val errorState = store.currentState as TodoState.Error
+        assertIs<AppState.Error>(store.currentState)
+        val errorState = store.currentState as AppState.Error
         assertEquals("Failed to add todo", errorState.message)
-    }
-}
-
-// Todo item data class
-private data class Todo(
-    val id: String,
-    val title: String,
-    val completed: Boolean = false,
-)
-
-// State definitions
-private sealed interface TodoState : State {
-    data object Idle : TodoState
-    data object Loading : TodoState
-    data class Loaded(val todos: List<Todo>) : TodoState
-    data class Editing(val editingTodo: Todo, val allTodos: List<Todo>) : TodoState
-    data class Error(val message: String) : TodoState
-}
-
-// Action definitions
-private sealed interface TodoAction : Action {
-    data object LoadTodos : TodoAction
-    data class AddTodo(val title: String) : TodoAction
-    data class ToggleCompletion(val todoId: String) : TodoAction
-    data class DeleteTodo(val todoId: String) : TodoAction
-    data class StartEditing(val todoId: String) : TodoAction
-    data class UpdateEditingTitle(val newTitle: String) : TodoAction
-    data object SaveEdit : TodoAction
-    data object CancelEdit : TodoAction
-    data object RetryFromError : TodoAction
-}
-
-// Simple ID counter for tests
-private var idCounter = 0
-
-// Helper function to generate IDs in a platform-independent way
-private fun generateId(): String {
-    val random = Random.nextInt(10000, 99999)
-    idCounter++
-    return "${abs(random)}_${idCounter}"
-}
-
-// Repository interface
-private interface TodoRepository {
-    suspend fun loadTodos(): List<Todo>
-    suspend fun addTodo(todo: Todo): Todo
-    suspend fun updateTodo(todo: Todo): Todo
-    suspend fun deleteTodo(todoId: String): Boolean
-}
-
-// Mock repository implementation
-private class MockTodoRepository(var shouldSucceed: Boolean) : TodoRepository {
-    val initialTodos = listOf(
-        Todo("1", "Complete project", false),
-        Todo("2", "Write tests", true),
-        Todo("3", "Review code", false),
-    )
-
-    private val _todos = initialTodos.toMutableList()
-
-    override suspend fun loadTodos(): List<Todo> {
-        if (!shouldSucceed) throw Exception("Failed to load todos")
-        return _todos.toList()
-    }
-
-    override suspend fun addTodo(todo: Todo): Todo {
-        if (!shouldSucceed) throw Exception("Failed to add todo")
-        _todos.add(todo)
-        return todo
-    }
-
-    override suspend fun updateTodo(todo: Todo): Todo {
-        if (!shouldSucceed) throw Exception("Failed to update todo")
-        val index = _todos.indexOfFirst { it.id == todo.id }
-        if (index >= 0) {
-            _todos[index] = todo
-        }
-        return todo
-    }
-
-    override suspend fun deleteTodo(todoId: String): Boolean {
-        if (!shouldSucceed) throw Exception("Failed to delete todo")
-        val initialSize = _todos.size
-        _todos.removeAll { it.id == todoId }
-        return _todos.size < initialSize
-    }
-}
-
-// Store factory
-private fun createTodoStore(
-    repository: TodoRepository = MockTodoRepository(true),
-    initialState: TodoState = TodoState.Idle,
-): Store<TodoState, TodoAction, Nothing> {
-    return Store(initialState) {
-        coroutineContext(Dispatchers.Unconfined)
-
-        // Idle state handling
-        state<TodoState.Idle> {
-            action<TodoAction.LoadTodos> {
-                nextState(TodoState.Loading)
-            }
-        }
-
-        // Loading state handling
-        state<TodoState.Loading> {
-            enter {
-                val todos = repository.loadTodos()
-                nextState(TodoState.Loaded(todos))
-            }
-        }
-
-        // Loaded state handling
-        state<TodoState.Loaded> {
-            action<TodoAction.AddTodo> {
-                val newTodo = Todo(
-                    id = generateId(),
-                    title = action.title,
-                    completed = false,
-                )
-                val savedTodo = repository.addTodo(newTodo)
-                nextState(state.copy(todos = state.todos + savedTodo))
-            }
-
-            action<TodoAction.ToggleCompletion> {
-                val todoToUpdate = state.todos.first { it.id == action.todoId }
-                val updatedTodo = todoToUpdate.copy(completed = !todoToUpdate.completed)
-                val savedTodo = repository.updateTodo(updatedTodo)
-                
-                nextStateBy {
-                    // Create updated todo list
-                    val updatedTodoList = state.todos.map {
-                        if (it.id == action.todoId) savedTodo else it
-                    }
-                    
-                    state.copy(todos = updatedTodoList)
-                }
-            }
-
-            action<TodoAction.DeleteTodo> {
-                val success = repository.deleteTodo(action.todoId)
-                if (success) {
-                    nextState(state.copy(todos = state.todos.filter { it.id != action.todoId }))
-                }
-            }
-
-            action<TodoAction.StartEditing> {
-                val todoToEdit = state.todos.first { it.id == action.todoId }
-                nextState(TodoState.Editing(todoToEdit, state.todos))
-            }
-        }
-
-        // Editing state handling
-        state<TodoState.Editing> {
-            action<TodoAction.UpdateEditingTitle> {
-                nextState(state.copy(editingTodo = state.editingTodo.copy(title = action.newTitle)))
-            }
-
-            action<TodoAction.SaveEdit> {
-                // Save edited content to repository
-                val savedTodo = repository.updateTodo(state.editingTodo)
-                
-                nextStateBy {
-                    // Create updated todo list with the edited task
-                    val updatedTodoList = state.allTodos.map {
-                        if (it.id == savedTodo.id) savedTodo else it
-                    }
-                    
-                    // Transition from editing state to loaded state
-                    TodoState.Loaded(updatedTodoList)
-                }
-            }
-
-            action<TodoAction.CancelEdit> {
-                nextState(TodoState.Loaded(state.allTodos))
-            }
-        }
-
-        // Error state handling
-        state<TodoState.Error> {
-            action<TodoAction.RetryFromError> {
-                nextState(TodoState.Idle)
-            }
-        }
-
-        // Global error handling
-        state<TodoState> {
-            error<Exception> {
-                nextState(TodoState.Error(error.message ?: "Unknown error"))
-            }
-        }
     }
 }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/WebSocketUseCaseTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/WebSocketUseCaseTest.kt
@@ -43,6 +43,163 @@ class WebSocketUseCaseTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    // Domain models
+    data class WebSocketMessage(
+        val id: String,
+        val content: String,
+        val timestamp: Long,
+    )
+
+    // WebSocket service interfaces
+    interface WebSocketService {
+        fun connect()
+        fun disconnect()
+        val connectionEvents: Flow<ConnectionEvent>
+        val messages: Flow<WebSocketMessage>
+
+        sealed interface ConnectionEvent {
+            data object Connected : ConnectionEvent
+            data object Disconnected : ConnectionEvent
+            data class Error(val throwable: Throwable) : ConnectionEvent
+        }
+    }
+
+    // Mock implementation for testing
+    class MockWebSocketService : WebSocketService {
+        private val connectionChannel = Channel<WebSocketService.ConnectionEvent>(Channel.BUFFERED)
+        private val messageChannel = Channel<WebSocketMessage>(Channel.BUFFERED)
+
+        override val connectionEvents: Flow<WebSocketService.ConnectionEvent> = connectionChannel.receiveAsFlow()
+        override val messages: Flow<WebSocketMessage> = messageChannel.receiveAsFlow()
+
+        override fun connect() {
+            // Connection logic happens in simulation methods for testing
+        }
+
+        override fun disconnect() {
+            // In real implementation, this would trigger the actual disconnect
+            // The event itself is sent by simulateConnectionClosed() for testing
+        }
+
+        fun simulateConnectionEstablished() {
+            connectionChannel.trySend(WebSocketService.ConnectionEvent.Connected)
+        }
+
+        fun simulateConnectionError(error: Throwable) {
+            connectionChannel.trySend(WebSocketService.ConnectionEvent.Error(error))
+        }
+
+        fun simulateConnectionClosed() {
+            connectionChannel.trySend(WebSocketService.ConnectionEvent.Disconnected)
+        }
+
+        fun simulateMessageReceived(message: WebSocketMessage) {
+            messageChannel.trySend(message)
+        }
+    }
+
+    // Tart State definitions
+    sealed interface AppState : State {
+        data object Disconnected : AppState
+
+        data class Connected(
+            val connectionStatus: ConnectionStatus = ConnectionStatus.CONNECTING,
+            val latestMessage: WebSocketMessage? = null,
+        ) : AppState
+
+        data class Error(val error: Throwable) : AppState
+
+        enum class ConnectionStatus {
+            CONNECTING, CONNECTED, DISCONNECTING
+        }
+    }
+
+    // Tart Action definitions
+    sealed interface AppAction : Action {
+        data object Connect : AppAction
+        data object Disconnect : AppAction
+    }
+
+    private fun createTestStore(
+        webSocketService: WebSocketService,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store {
+            initialState(AppState.Disconnected)
+            coroutineContext(Dispatchers.Unconfined)
+
+            state<AppState.Disconnected> {
+                action<AppAction.Connect> {
+                    nextState(AppState.Connected(connectionStatus = AppState.ConnectionStatus.CONNECTING))
+                }
+            }
+
+            state<AppState.Connected> {
+                enter {
+                    // Skip if not in CONNECTING status (early return pattern)
+                    if (state.connectionStatus != AppState.ConnectionStatus.CONNECTING) {
+                        return@enter
+                    }
+
+                    // Initiate connection
+                    webSocketService.connect()
+
+                    // Monitor both connection events and messages in a single state
+                    launch {
+                        webSocketService.connectionEvents.collect { event ->
+                            when (event) {
+                                is WebSocketService.ConnectionEvent.Connected -> {
+                                    transaction {
+                                        nextState(state.copy(connectionStatus = AppState.ConnectionStatus.CONNECTED))
+                                    }
+                                }
+
+                                is WebSocketService.ConnectionEvent.Error -> {
+                                    transaction {
+                                        nextState(AppState.Error(event.throwable))
+                                    }
+                                }
+
+                                is WebSocketService.ConnectionEvent.Disconnected -> {
+                                    transaction {
+                                        nextState(AppState.Disconnected)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    launch {
+                        webSocketService.messages.collect { message ->
+                            transaction {
+                                // Only update messages if in CONNECTED status
+                                if (state.connectionStatus == AppState.ConnectionStatus.CONNECTED) {
+                                    nextState(state.copy(latestMessage = message))
+                                }
+                                // Otherwise ignore messages that arrive before fully connected
+                                // or after disconnecting has started
+                            }
+                        }
+                    }
+                }
+
+                action<AppAction.Disconnect> {
+                    // First update state to disconnecting
+                    nextState(state.copy(connectionStatus = AppState.ConnectionStatus.DISCONNECTING))
+
+                    // Then initiate disconnect
+                    webSocketService.disconnect()
+                    // Actual state change to Disconnected will happen through the event flow
+                }
+            }
+
+            state<AppState.Error> {
+                action<AppAction.Connect> {
+                    nextState(AppState.Connected(connectionStatus = AppState.ConnectionStatus.CONNECTING))
+                }
+            }
+        }
+    }
+
     @Test
     fun webSocket_shouldConnectAndHandleMessages() = runTest(testDispatcher) {
         // Mock implementation of WebSocket service
@@ -52,23 +209,23 @@ class WebSocketUseCaseTest {
         val store = createTestStore(mockWebSocket)
 
         // Initial state should be Disconnected
-        assertIs<WebSocketState.Disconnected>(store.currentState)
+        assertIs<AppState.Disconnected>(store.currentState)
 
         // Connect to WebSocket
-        store.dispatch(WebSocketAction.Connect)
+        store.dispatch(AppAction.Connect)
 
         // State should change to Connected with CONNECTING status
         val connectingState = store.currentState
-        assertIs<WebSocketState.Connected>(connectingState)
-        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+        assertIs<AppState.Connected>(connectingState)
+        assertEquals(AppState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
 
         // Simulate connection success
         mockWebSocket.simulateConnectionEstablished()
 
         // State should change to Connected with CONNECTED status
         val connectedState = store.currentState
-        assertIs<WebSocketState.Connected>(connectedState)
-        assertEquals(WebSocketState.ConnectionStatus.CONNECTED, connectedState.connectionStatus)
+        assertIs<AppState.Connected>(connectedState)
+        assertEquals(AppState.ConnectionStatus.CONNECTED, connectedState.connectionStatus)
 
         // Simulate receiving a message
         val testMessage = WebSocketMessage("test-id", "Test message", 1234567890L) // Using fixed timestamp for test
@@ -76,23 +233,23 @@ class WebSocketUseCaseTest {
 
         // State should update with the latest message
         val stateWithMessage = store.currentState
-        assertIs<WebSocketState.Connected>(stateWithMessage)
+        assertIs<AppState.Connected>(stateWithMessage)
         assertEquals(testMessage, stateWithMessage.latestMessage)
-        assertEquals(WebSocketState.ConnectionStatus.CONNECTED, stateWithMessage.connectionStatus)
+        assertEquals(AppState.ConnectionStatus.CONNECTED, stateWithMessage.connectionStatus)
 
         // Disconnect
-        store.dispatch(WebSocketAction.Disconnect)
+        store.dispatch(AppAction.Disconnect)
 
         // State should first change to DISCONNECTING
         val disconnectingState = store.currentState
-        assertIs<WebSocketState.Connected>(disconnectingState)
-        assertEquals(WebSocketState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
+        assertIs<AppState.Connected>(disconnectingState)
+        assertEquals(AppState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
 
         // After the disconnect event is processed, state should return to Disconnected
         mockWebSocket.simulateConnectionClosed()
 
         // State should return to Disconnected
-        assertIs<WebSocketState.Disconnected>(store.currentState)
+        assertIs<AppState.Disconnected>(store.currentState)
     }
 
     @Test
@@ -104,12 +261,12 @@ class WebSocketUseCaseTest {
         val store = createTestStore(mockWebSocket)
 
         // Connect to WebSocket
-        store.dispatch(WebSocketAction.Connect)
+        store.dispatch(AppAction.Connect)
 
         // Verify we're in CONNECTING status
         val connectingState = store.currentState
-        assertIs<WebSocketState.Connected>(connectingState)
-        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+        assertIs<AppState.Connected>(connectingState)
+        assertEquals(AppState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
 
         // Simulate connection failure
         val error = Exception("Connection refused")
@@ -117,7 +274,7 @@ class WebSocketUseCaseTest {
 
         // State should change to Error
         val errorState = store.currentState
-        assertIs<WebSocketState.Error>(errorState)
+        assertIs<AppState.Error>(errorState)
         assertEquals(error, errorState.error)
     }
 
@@ -130,181 +287,24 @@ class WebSocketUseCaseTest {
         val store = createTestStore(mockWebSocket)
 
         // Connect to WebSocket
-        store.dispatch(WebSocketAction.Connect)
+        store.dispatch(AppAction.Connect)
 
         // Verify we're in CONNECTING status
         val connectingState = store.currentState
-        assertIs<WebSocketState.Connected>(connectingState)
-        assertEquals(WebSocketState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
+        assertIs<AppState.Connected>(connectingState)
+        assertEquals(AppState.ConnectionStatus.CONNECTING, connectingState.connectionStatus)
 
         // Disconnect while still connecting
-        store.dispatch(WebSocketAction.Disconnect)
+        store.dispatch(AppAction.Disconnect)
 
         // State should first change to DISCONNECTING
         val disconnectingState = store.currentState
-        assertIs<WebSocketState.Connected>(disconnectingState)
-        assertEquals(WebSocketState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
+        assertIs<AppState.Connected>(disconnectingState)
+        assertEquals(AppState.ConnectionStatus.DISCONNECTING, disconnectingState.connectionStatus)
 
         // After the disconnect event is processed, state should return to Disconnected
         mockWebSocket.simulateConnectionClosed()
 
-        assertIs<WebSocketState.Disconnected>(store.currentState)
-    }
-}
-
-// Domain models
-private data class WebSocketMessage(
-    val id: String,
-    val content: String,
-    val timestamp: Long,
-)
-
-// WebSocket service interfaces
-private interface WebSocketService {
-    fun connect()
-    fun disconnect()
-    val connectionEvents: Flow<ConnectionEvent>
-    val messages: Flow<WebSocketMessage>
-
-    sealed interface ConnectionEvent {
-        data object Connected : ConnectionEvent
-        data object Disconnected : ConnectionEvent
-        data class Error(val throwable: Throwable) : ConnectionEvent
-    }
-}
-
-// Mock implementation for testing
-private class MockWebSocketService : WebSocketService {
-    private val connectionChannel = Channel<WebSocketService.ConnectionEvent>(Channel.BUFFERED)
-    private val messageChannel = Channel<WebSocketMessage>(Channel.BUFFERED)
-
-    override val connectionEvents: Flow<WebSocketService.ConnectionEvent> = connectionChannel.receiveAsFlow()
-    override val messages: Flow<WebSocketMessage> = messageChannel.receiveAsFlow()
-
-    override fun connect() {
-        // Connection logic happens in simulation methods for testing
-    }
-
-    override fun disconnect() {
-        // In real implementation, this would trigger the actual disconnect
-        // The event itself is sent by simulateConnectionClosed() for testing
-    }
-
-    fun simulateConnectionEstablished() {
-        connectionChannel.trySend(WebSocketService.ConnectionEvent.Connected)
-    }
-
-    fun simulateConnectionError(error: Throwable) {
-        connectionChannel.trySend(WebSocketService.ConnectionEvent.Error(error))
-    }
-
-    fun simulateConnectionClosed() {
-        connectionChannel.trySend(WebSocketService.ConnectionEvent.Disconnected)
-    }
-
-    fun simulateMessageReceived(message: WebSocketMessage) {
-        messageChannel.trySend(message)
-    }
-}
-
-// Tart State definitions
-private sealed interface WebSocketState : State {
-    data object Disconnected : WebSocketState
-
-    data class Connected(
-        val connectionStatus: ConnectionStatus = ConnectionStatus.CONNECTING,
-        val latestMessage: WebSocketMessage? = null,
-    ) : WebSocketState
-
-    data class Error(val error: Throwable) : WebSocketState
-
-    enum class ConnectionStatus {
-        CONNECTING, CONNECTED, DISCONNECTING
-    }
-}
-
-// Tart Action definitions
-private sealed interface WebSocketAction : Action {
-    data object Connect : WebSocketAction
-    data object Disconnect : WebSocketAction
-}
-
-private fun createTestStore(
-    webSocketService: WebSocketService,
-): Store<WebSocketState, WebSocketAction, Nothing> {
-    return Store {
-        initialState(WebSocketState.Disconnected)
-        coroutineContext(Dispatchers.Unconfined)
-
-        state<WebSocketState.Disconnected> {
-            action<WebSocketAction.Connect> {
-                nextState(WebSocketState.Connected(connectionStatus = WebSocketState.ConnectionStatus.CONNECTING))
-            }
-        }
-
-        state<WebSocketState.Connected> {
-            enter {
-                // Skip if not in CONNECTING status (early return pattern)
-                if (state.connectionStatus != WebSocketState.ConnectionStatus.CONNECTING) {
-                    return@enter
-                }
-
-                // Initiate connection
-                webSocketService.connect()
-
-                // Monitor both connection events and messages in a single state
-                launch {
-                    webSocketService.connectionEvents.collect { event ->
-                        when (event) {
-                            is WebSocketService.ConnectionEvent.Connected -> {
-                                transaction {
-                                    nextState(state.copy(connectionStatus = WebSocketState.ConnectionStatus.CONNECTED))
-                                }
-                            }
-
-                            is WebSocketService.ConnectionEvent.Error -> {
-                                transaction {
-                                    nextState(WebSocketState.Error(event.throwable))
-                                }
-                            }
-
-                            is WebSocketService.ConnectionEvent.Disconnected -> {
-                                transaction {
-                                    nextState(WebSocketState.Disconnected)
-                                }
-                            }
-                        }
-                    }
-                }
-
-                launch {
-                    webSocketService.messages.collect { message ->
-                        transaction {
-                            // Only update messages if in CONNECTED status
-                            if (state.connectionStatus == WebSocketState.ConnectionStatus.CONNECTED) {
-                                nextState(state.copy(latestMessage = message))
-                            }
-                            // Otherwise ignore messages that arrive before fully connected
-                            // or after disconnecting has started
-                        }
-                    }
-                }
-            }
-
-            action<WebSocketAction.Disconnect> {
-                // First update state to disconnecting
-                nextState(state.copy(connectionStatus = WebSocketState.ConnectionStatus.DISCONNECTING))
-
-                // Then initiate disconnect
-                webSocketService.disconnect()
-                // Actual state change to Disconnected will happen through the event flow
-            }
-        }
-
-        state<WebSocketState.Error> {
-            action<WebSocketAction.Connect> {
-                nextState(WebSocketState.Connected(connectionStatus = WebSocketState.ConnectionStatus.CONNECTING))
-            }
-        }
+        assertIs<AppState.Disconnected>(store.currentState)
     }
 }


### PR DESCRIPTION
## Summary
- Standardized all test store creation function names to 'createTestStore()' for consistency
- Improved test code readability and maintainability
- Merged multiple store creation functions in StoreStateCoroutineScopeTest into a single parameterized function

🤖 Generated with [Claude Code](https://claude.ai/code)