### PR TITLE
Rename Store lambda parameter to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ fun CounterStore(
         }
 
         // ...
+
+// or, 
+class CounterStore(
+    counterRepository: CounterRepository,
+): Store<CounterState, CounterAction, CounterEvent> by Store(
+    configure = {
+        initialState(CounterState(count = 0))
+        
+        // ...
+    },
+)
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -199,15 +199,18 @@ fun CounterStore(
         }
 
         // ...
+    }
+}
 
-// or, 
+// or, define a Store class using delegation
 class CounterStore(
     counterRepository: CounterRepository,
 ): Store<CounterState, CounterAction, CounterEvent> by Store(
+    initialState = CounterState(count = 0),
     configure = {
-        initialState(CounterState(count = 0))
-        
-        // ...
+        state<CounterState> {
+            // ...
+        }
     },
 )
 ```

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -261,16 +261,16 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
  * Creates a Store instance with the specified initial state and optional configuration.
  *
  * @param initialState The initial state of the store
- * @param block Optional configuration block to customize the store
+ * @param configure Optional configuration block to customize the store
  * @return A configured Store instance
  */
 fun <S : State, A : Action, E : Event> Store(
     initialState: S,
-    block: StoreBuilder<S, A, E>.() -> Unit,
+    configure: StoreBuilder<S, A, E>.() -> Unit,
 ): Store<S, A, E> {
     return StoreBuilder<S, A, E>().apply {
         initialState(initialState)
-        block()
+        configure()
     }.build()
 }
 
@@ -278,12 +278,12 @@ fun <S : State, A : Action, E : Event> Store(
  * Creates a Store instance with configuration provided in the block.
  * The initial state must be set within the block using initialState().
  *
- * @param block Configuration block to customize the store
+ * @param configure Configuration block to customize the store
  * @return A configured Store instance
  * @throws IllegalArgumentException if the initial state is not set in the block
  */
 fun <S : State, A : Action, E : Event> Store(
-    block: StoreBuilder<S, A, E>.() -> Unit,
+    configure: StoreBuilder<S, A, E>.() -> Unit,
 ): Store<S, A, E> {
-    return StoreBuilder<S, A, E>().apply(block).build()
+    return StoreBuilder<S, A, E>().apply(configure).build()
 }


### PR DESCRIPTION
## Summary
- Rename the Store factory lambda parameter from `block` to `configure` in both overloads.
- Update KDoc parameter names to match the new API.
- Add a README example that uses `Store(configure = { ... })`.

## Why
- `configure` better communicates that the lambda configures the store, especially when using named arguments.
- This reduces confusion compared to `block`, which is generic and less descriptive.

## Notes
- Named-argument call sites using `block = ...` must be updated to `configure = ...`.

## Verification
- Not run (API/documentation rename only).