### PR TITLE
Support action-specific launch scope

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,8 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 180
+# max_line_length = 180
+max_line_length = off
 trim_trailing_whitespace = true
 
 [*.md]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ By combining Tart with Kotlin `sealed class`/`sealed interface`, you can model e
   - [Access repositories and UseCase classes](#access-repositories-and-usecase-classes)
   - [Multiple states and transitions](#multiple-states-and-transitions)
   - [Error handling](#error-handling)
-  - [Collecting Flows](#collecting-flows)
+  - [Asynchronous Work](#asynchronous-work)
   - [Specifying coroutineContext](#specifying-coroutinecontext)
     - [Specifying CoroutineDispatchers](#specifying-coroutinedispatchers)
   - [State Persistence](#state-persistence)
@@ -372,10 +372,10 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 }
 ```
 
-### Collecting Flows
+### Asynchronous Work
 
-You can use the `launch{}` specification in the `enter{}` block to collect flows and update *State* (or emit *Event*s).
-This is useful for connecting external data streams to your *Store*:
+You can use `launch{}` in both `enter{}` and `action{}` blocks to run asynchronous work and update *State* (or emit *Event*s).
+This is useful for integrating long-running tasks such as flow collection, network calls, and background processing:
 
 ```kt
 state<MyState.Active> {
@@ -394,8 +394,30 @@ state<MyState.Active> {
 }
 ```
 
+You can also start asynchronous work from an action:
+
+```kt
+state<MyState.Active> {
+    action<MyAction.Refresh> {
+        launch {
+            // state updates in launch must be done in transaction
+            transaction {
+                nextState(state.copy(isRefreshing = true))
+            }
+
+            dataRepository.refresh()
+
+            transaction {
+                nextState(state.copy(isRefreshing = false))
+            }
+        }
+    }
+}
+```
+
 This pattern lets your *Store* react to external data changes automatically, such as database updates, user preference changes, or network events.
-The flow collection will be automatically cancelled when the *State* changes to a different *State*, making it easy to manage resources and subscriptions.
+Coroutines started by `launch{}` are automatically cancelled when the *State* changes to a different *State*, making it easy to manage resources and subscriptions.
+In `action{}`, `launch{}` is tied to the *State* active at action start.
 
 ### Specifying coroutineContext
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 
 You can use `launch{}` in both `enter{}` and `action{}` blocks to run asynchronous work and update *State* (or emit *Event*s).
 This is useful for integrating long-running tasks such as flow collection, network calls, and background processing:
+If you prefer a shorter form, use `enterAsync{}` / `actionAsync{}`, which are shorthand for `enter { launch { ... } }` / `action<...> { launch { ... } }`.
 
 ```kt
 state<MyState.Active> {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -131,6 +131,19 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         }
 
         /**
+         * Registers an asynchronous enter handler.
+         * This is a shorthand of `enter { launch { ... } }`.
+         *
+         * @param coroutineDispatcher The CoroutineDispatcher used for the launched coroutine
+         * @param block The asynchronous handler block
+         */
+        fun enterAsync(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend EnterScope.LaunchScope<S, E, S2>.() -> Unit) {
+            enter {
+                launch(coroutineDispatcher, block)
+            }
+        }
+
+        /**
          * Registers a handler for a specific action type in the current state configuration
          * with an optional CoroutineDispatcher.
          *
@@ -148,6 +161,19 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
                     },
                 ),
             )
+        }
+
+        /**
+         * Registers an asynchronous action handler for a specific action type.
+         * This is a shorthand of `action { launch { ... } }`.
+         *
+         * @param coroutineDispatcher The CoroutineDispatcher used for the launched coroutine
+         * @param block The asynchronous handler block
+         */
+        inline fun <reified A2 : A> actionAsync(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, noinline block: suspend ActionScope.LaunchScope<S, A2, E, S2>.() -> Unit) {
+            action<A2> {
+                launch(coroutineDispatcher, block)
+            }
         }
 
         /**

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -266,6 +266,16 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 override suspend fun event(event: E) {
                     emit(event)
                 }
+
+                override fun launch(coroutineDispatcher: CoroutineDispatcher, block: suspend ActionScope.LaunchScope<S, A, E, S>.() -> Unit) {
+                    val stateScope = stateScopes[state::class] ?: throw InternalError(IllegalStateException("[Tart] State scope is not found"))
+                    launchInStateScope(
+                        stateScope = stateScope,
+                        coroutineDispatcher = coroutineDispatcher,
+                        buildLaunchScope = { buildActionLaunchScope(stateScope, action) },
+                        block = block,
+                    )
+                }
             },
         )
         val nextState = newState ?: state
@@ -295,72 +305,143 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 }
 
                 override fun launch(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope<S, E, S>.() -> Unit) {
-                    stateScope.launch(coroutineDispatcher) {
-                        val launchScope = object : EnterScope.LaunchScope<S, E, S> {
-                            override val isActive: Boolean get() = stateScope.isActive
-                            override suspend fun event(event: E) {
-                                emit(event)
-                            }
-
-                            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
-                                val job = coroutineScope.launch(coroutineDispatcher) {
-                                    mutex.withLock {
-                                        if (stateScope.isActive) {
-                                            var newStateInBlock: S? = null
-                                            val transactionScope = object : EnterScope.LaunchScope.TransactionScope<S, E, S> {
-                                                override val state: S = currentState
-                                                override fun nextState(state: S) {
-                                                    newStateInBlock = state
-                                                }
-
-                                                override fun nextStateBy(block: () -> S) {
-                                                    newStateInBlock = block()
-                                                }
-
-                                                override suspend fun event(event: E) {
-                                                    emit(event)
-                                                }
-                                            }
-                                            try {
-                                                block(transactionScope)
-                                            } catch (t: Throwable) {
-                                                if (t is CancellationException) {
-                                                    throw t
-                                                }
-                                                onErrorOccurred(currentState, t)
-                                                return@withLock
-                                            }
-                                            val nextState = newStateInBlock ?: currentState
-                                            if (nextState != currentState) {
-                                                onStateChanged(currentState, nextState)
-                                            }
-                                        }
-                                    }
-                                }
-                                job.join()
-                            }
-                        }
-                        try {
-                            block(launchScope)
-                        } catch (t: Throwable) {
-                            if (t is CancellationException) {
-                                throw t
-                            }
-                            coroutineScope.launch(coroutineDispatcher) {
-                                mutex.withLock {
-                                    if (stateScope.isActive) {
-                                        onErrorOccurred(currentState, t)
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    launchInStateScope(
+                        stateScope = stateScope,
+                        coroutineDispatcher = coroutineDispatcher,
+                        buildLaunchScope = { buildEnterLaunchScope(stateScope) },
+                        block = block,
+                    )
                 }
             },
         )
         val nextState = newState ?: state
         processMiddleware { afterStateEnter(state, nextState) }
         return nextState
+    }
+
+    private fun <LS> launchInStateScope(
+        stateScope: CoroutineScope,
+        coroutineDispatcher: CoroutineDispatcher,
+        buildLaunchScope: () -> LS,
+        block: suspend LS.() -> Unit,
+    ) {
+        stateScope.launch(coroutineDispatcher) {
+            val launchScope = buildLaunchScope()
+            try {
+                block(launchScope)
+            } catch (t: Throwable) {
+                if (t is CancellationException) {
+                    throw t
+                }
+                coroutineScope.launch(coroutineDispatcher) {
+                    mutex.withLock {
+                        if (stateScope.isActive) {
+                            onErrorOccurred(currentState, t)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun buildEnterLaunchScope(stateScope: CoroutineScope): EnterScope.LaunchScope<S, E, S> {
+        return object : EnterScope.LaunchScope<S, E, S> {
+            override val isActive: Boolean get() = stateScope.isActive
+
+            override suspend fun event(event: E) {
+                emit(event)
+            }
+
+            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend EnterScope.LaunchScope.TransactionScope<S, E, S>.() -> Unit) {
+                val job = coroutineScope.launch(coroutineDispatcher) {
+                    mutex.withLock {
+                        if (stateScope.isActive) {
+                            var newState: S? = null
+                            val transactionScope = object : EnterScope.LaunchScope.TransactionScope<S, E, S> {
+                                override val state: S = currentState
+
+                                override fun nextState(state: S) {
+                                    newState = state
+                                }
+
+                                override fun nextStateBy(block: () -> S) {
+                                    newState = block()
+                                }
+
+                                override suspend fun event(event: E) {
+                                    emit(event)
+                                }
+                            }
+                            try {
+                                block(transactionScope)
+                            } catch (t: Throwable) {
+                                if (t is CancellationException) {
+                                    throw t
+                                }
+                                onErrorOccurred(currentState, t)
+                                return@withLock
+                            }
+                            val nextState = newState ?: currentState
+                            if (nextState != currentState) {
+                                onStateChanged(currentState, nextState)
+                            }
+                        }
+                    }
+                }
+                job.join()
+            }
+        }
+    }
+
+    private fun buildActionLaunchScope(stateScope: CoroutineScope, launchedAction: A): ActionScope.LaunchScope<S, A, E, S> {
+        return object : ActionScope.LaunchScope<S, A, E, S> {
+            override val isActive: Boolean get() = stateScope.isActive
+            override val action: A = launchedAction
+
+            override suspend fun event(event: E) {
+                emit(event)
+            }
+
+            override suspend fun transaction(coroutineDispatcher: CoroutineDispatcher, block: suspend ActionScope.LaunchScope.TransactionScope<S, A, E, S>.() -> Unit) {
+                val job = coroutineScope.launch(coroutineDispatcher) {
+                    mutex.withLock {
+                        if (stateScope.isActive) {
+                            var newState: S? = null
+                            val transactionScope = object : ActionScope.LaunchScope.TransactionScope<S, A, E, S> {
+                                override val state: S = currentState
+                                override val action: A = launchedAction
+
+                                override fun nextState(state: S) {
+                                    newState = state
+                                }
+
+                                override fun nextStateBy(block: () -> S) {
+                                    newState = block()
+                                }
+
+                                override suspend fun event(event: E) {
+                                    emit(event)
+                                }
+                            }
+                            try {
+                                block(transactionScope)
+                            } catch (t: Throwable) {
+                                if (t is CancellationException) {
+                                    throw t
+                                }
+                                onErrorOccurred(currentState, t)
+                                return@withLock
+                            }
+                            val nextState = newState ?: currentState
+                            if (nextState != currentState) {
+                                onStateChanged(currentState, nextState)
+                            }
+                        }
+                    }
+                }
+                job.join()
+            }
+        }
     }
 
     private suspend fun processStateExit(state: S) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -181,6 +181,93 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * @param event The event to emit
      */
     suspend fun event(event: E)
+
+    /**
+     * Launches a coroutine within the context of the current state where this action is processed.
+     * The coroutine will be automatically cancelled when this state is exited.
+     *
+     * @param coroutineDispatcher The CoroutineDispatcher to use for this coroutine (defaults to Dispatchers.Unconfined)
+     * @param block The suspending block of code to execute
+     */
+    fun launch(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend LaunchScope<S, A, E, S2>.() -> Unit)
+
+    /**
+     * Scope available within a launched coroutine from an action handler.
+     * Used for long-running operations or side effects within a state.
+     */
+    @TartStoreDsl
+    interface LaunchScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
+        /**
+         * Checks if the coroutine scope is still active.
+         * Use this to verify if the state is still active before performing operations.
+         *
+         * @return True if the scope is still active, false otherwise
+         */
+        val isActive: Boolean
+
+        /**
+         * The action being processed when the launch was started.
+         */
+        val action: A
+
+        /**
+         * Emits an event from the launched coroutine.
+         * Use this to communicate with the outside world about important occurrences.
+         *
+         * @param event The event to emit
+         */
+        suspend fun event(event: E)
+
+        /**
+         * Executes a transactional operation within the launch scope.
+         * This allows state updates to be performed in an atomic, consistent manner.
+         *
+         * @param coroutineDispatcher The CoroutineDispatcher to use for this operation (defaults to Dispatchers.Unconfined)
+         * @param block The suspending block of code to execute as a transaction
+         */
+        suspend fun transaction(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Unconfined, block: suspend TransactionScope<S, A, E, S2>.() -> Unit)
+
+        /**
+         * Scope available within a transaction operation.
+         * Used for atomic state updates with consistency guarantees.
+         */
+        @TartStoreDsl
+        interface TransactionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
+            /**
+             * The current state when the transaction is being executed
+             */
+            val state: S2
+
+            /**
+             * The action being processed when the launch was started.
+             */
+            val action: A
+
+            /**
+             * Updates the current state with a new state value.
+             * Used within transaction blocks to modify the state.
+             *
+             * @param state The new state value to update to
+             */
+            fun nextState(state: S)
+
+            /**
+             * Updates the current state with a new state value computed from the given block.
+             * Used within transaction blocks to modify the state with computed values.
+             *
+             * @param block A function that computes and returns the new state
+             */
+            fun nextStateBy(block: () -> S)
+
+            /**
+             * Emits an event from the transaction.
+             * Use this to communicate with the outside world about important occurrences.
+             *
+             * @param event The event to emit
+             */
+            suspend fun event(event: E)
+        }
+    }
 }
 
 /**

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
@@ -24,6 +24,7 @@ class StoreActionCoroutineScopeTest {
     sealed interface AppAction : Action {
         data object LaunchIncrement : AppAction
         data class LaunchWithDelta(val delta: Int) : AppAction
+        data class LaunchAsyncWithDelta(val delta: Int) : AppAction
         data object LaunchLongRunning : AppAction
         data object MoveToCompleted : AppAction
         data object MoveToCompletedThenLaunch : AppAction
@@ -53,6 +54,13 @@ class StoreActionCoroutineScopeTest {
                         transaction {
                             nextState(state.copy(value = state.value + delta + action.delta))
                         }
+                    }
+                }
+
+                actionAsync<AppAction.LaunchAsyncWithDelta> {
+                    val delta = action.delta
+                    transaction {
+                        nextState(state.copy(value = state.value + delta + action.delta))
                     }
                 }
 
@@ -118,6 +126,16 @@ class StoreActionCoroutineScopeTest {
         val store = createTestStore()
 
         store.dispatch(AppAction.LaunchWithDelta(delta = 2))
+        yield()
+
+        assertEquals(AppState.Active(value = 4), store.currentState)
+    }
+
+    @Test
+    fun actionAsync_canReferenceActionInLaunchAndTransaction() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.LaunchAsyncWithDelta(delta = 2))
         yield()
 
         assertEquals(AppState.Active(value = 4), store.currentState)

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreActionCoroutineScopeTest.kt
@@ -1,0 +1,175 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StoreActionCoroutineScopeTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    sealed interface AppState : State {
+        data class Active(val value: Int = 0) : AppState
+        data class Completed(val value: Int = 0) : AppState
+        data class Failed(val message: String) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object LaunchIncrement : AppAction
+        data class LaunchWithDelta(val delta: Int) : AppAction
+        data object LaunchLongRunning : AppAction
+        data object MoveToCompleted : AppAction
+        data object MoveToCompletedThenLaunch : AppAction
+        data object LaunchThrow : AppAction
+        data object LaunchTransactionThrow : AppAction
+    }
+
+    private fun createTestStore(
+        onLongRunningStart: (() -> Unit)? = null,
+        onLongRunningCancelled: (() -> Unit)? = null,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(AppState.Active()) {
+            coroutineContext(Dispatchers.Unconfined)
+
+            state<AppState.Active> {
+                action<AppAction.LaunchIncrement> {
+                    launch {
+                        transaction {
+                            nextState(state.copy(value = state.value + 1))
+                        }
+                    }
+                }
+
+                action<AppAction.LaunchWithDelta> {
+                    launch {
+                        val delta = action.delta
+                        transaction {
+                            nextState(state.copy(value = state.value + delta + action.delta))
+                        }
+                    }
+                }
+
+                action<AppAction.LaunchLongRunning> {
+                    launch {
+                        onLongRunningStart?.invoke()
+                        try {
+                            delay(Long.MAX_VALUE)
+                        } finally {
+                            onLongRunningCancelled?.invoke()
+                        }
+                    }
+                }
+
+                action<AppAction.MoveToCompleted> {
+                    nextState(AppState.Completed(value = state.value))
+                }
+
+                action<AppAction.MoveToCompletedThenLaunch> {
+                    nextState(AppState.Completed(value = state.value + 1))
+                    launch {
+                        transaction {
+                            nextState(AppState.Completed(value = 999))
+                        }
+                    }
+                }
+
+                action<AppAction.LaunchThrow> {
+                    launch {
+                        throw IllegalStateException("launch failed")
+                    }
+                }
+
+                action<AppAction.LaunchTransactionThrow> {
+                    launch {
+                        transaction {
+                            throw IllegalArgumentException("transaction failed")
+                        }
+                    }
+                }
+            }
+
+            state<AppState> {
+                error<Throwable> {
+                    nextState(AppState.Failed(error.message ?: "unknown"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun actionLaunch_updatesStateViaTransaction() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.LaunchIncrement)
+        yield()
+
+        assertEquals(AppState.Active(value = 1), store.currentState)
+    }
+
+    @Test
+    fun actionLaunch_canReferenceActionInLaunchAndTransaction() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.LaunchWithDelta(delta = 2))
+        yield()
+
+        assertEquals(AppState.Active(value = 4), store.currentState)
+    }
+
+    @Test
+    fun actionLaunch_isCancelledWhenStateChanges() = runTest(testDispatcher) {
+        var started = false
+        var cancelled = false
+        val store = createTestStore(
+            onLongRunningStart = { started = true },
+            onLongRunningCancelled = { cancelled = true },
+        )
+
+        store.dispatch(AppAction.LaunchLongRunning)
+        yield()
+        assertTrue(started, "Long-running action launch should start")
+
+        store.dispatch(AppAction.MoveToCompleted)
+        yield()
+
+        assertEquals(AppState.Completed(value = 0), store.currentState)
+        assertTrue(cancelled, "Long-running action launch should be cancelled on state transition")
+    }
+
+    @Test
+    fun actionLaunch_afterNextState_bindsToOriginalState() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.MoveToCompletedThenLaunch)
+        repeat(3) { yield() }
+
+        assertEquals(AppState.Completed(value = 1), store.currentState)
+    }
+
+    @Test
+    fun actionLaunch_exception_isHandledByErrorBlock() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.LaunchThrow)
+        repeat(3) { yield() }
+
+        assertEquals(AppState.Failed("launch failed"), store.currentState)
+    }
+
+    @Test
+    fun actionLaunch_transactionException_isHandledByErrorBlock() = runTest(testDispatcher) {
+        val store = createTestStore()
+
+        store.dispatch(AppAction.LaunchTransactionThrow)
+        repeat(3) { yield() }
+
+        assertEquals(AppState.Failed("transaction failed"), store.currentState)
+    }
+}

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StoreStateCoroutineScopeTest.kt
@@ -169,4 +169,28 @@ class StoreStateCoroutineScopeTest {
         // Verify background task was cancelled
         assertTrue(backgroundTaskCancelled, "Background task should have been cancelled")
     }
+
+    @Test
+    fun enterAsync_launchesCoroutineViaShorthand() = runTest(testDispatcher) {
+        val store: Store<AppState, AppAction, AppEvent> = Store(AppState.Initial) {
+            coroutineContext(Dispatchers.Unconfined)
+
+            state<AppState.Initial> {
+                action<AppAction.Start> {
+                    nextState(AppState.Running())
+                }
+            }
+
+            state<AppState.Running> {
+                enterAsync {
+                    transaction {
+                        nextState(state.copy(value = 7))
+                    }
+                }
+            }
+        }
+
+        store.dispatch(AppAction.Start)
+        assertEquals(AppState.Running(value = 7), store.currentState)
+    }
 }


### PR DESCRIPTION
## Summary
- Add `launch {}` support in `action {}` blocks.
- Introduce `ActionScope.LaunchScope`/`TransactionScope` so `action` can be referenced inside both `launch {}` and `transaction {}`.
- Keep `EnterScope` launch APIs as dedicated inner scopes and align implementation paths for enter/action launch execution.
- Preserve lifecycle behavior: coroutines launched from `action {}` are tied to the state active when the action started.
- Add and expand `StoreActionCoroutineScopeTest` to cover action access, cancellation, and error routing.
- Update README wording from flow-only framing to general asynchronous work and clarify action launch behavior.

## Verification
- `./gradlew :tart-core:jvmTest`