### PR TITLE
Rename ExceptionHandler default to Unhandled

### DIFF
--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/ExceptionHandler.kt
@@ -36,15 +36,21 @@ interface ExceptionHandler {
         }
 
         /**
-         * Default implementation of ExceptionHandler that rethrows all exceptions.
+         * Implementation of ExceptionHandler that leaves exceptions unhandled by rethrowing them.
          *
          * @return An ExceptionHandler instance that rethrows all exceptions
          */
-        val Default: ExceptionHandler = object : ExceptionHandler {
+        val Unhandled: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {
                 throw error
             }
         }
+
+        @Deprecated(
+            message = "Use Unhandled instead.",
+            replaceWith = ReplaceWith("ExceptionHandler.Unhandled"),
+        )
+        val Default: ExceptionHandler = Unhandled
     }
 }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -12,7 +12,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeInitialState: S? = null
     private var storeCoroutineContext: CoroutineContext = EmptyCoroutineContext + Dispatchers.Default
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
-    private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Default
+    private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**


### PR DESCRIPTION
## Summary
- Rename `ExceptionHandler.Default` to `ExceptionHandler.Unhandled`.
- Keep `Default` as a deprecated alias for compatibility.
- Update `StoreBuilder` to use `Unhandled` by default.

## Verification
- `./gradlew :tart-core:jvmTest`