### PR TITLE
Add pending action cancellation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ By combining Tart with Kotlin `sealed class`/`sealed interface`, you can model e
   - [Multiple states and transitions](#multiple-states-and-transitions)
   - [Error handling](#error-handling)
   - [Asynchronous Work](#asynchronous-work)
+  - [Cancel Pending Actions](#cancel-pending-actions)
+  - [Alternative DSL Forms](#alternative-dsl-forms)
   - [Specifying coroutineContext](#specifying-coroutinecontext)
     - [Specifying CoroutineDispatchers](#specifying-coroutinedispatchers)
   - [State Persistence](#state-persistence)
@@ -114,20 +116,6 @@ val store: Store<CounterState, CounterAction, Nothing> = Store(CounterState(coun
             }
         }
     }
-}
-```
-
-`anyState{}` lets you register handlers for all *States*, and `anyAction{}` can be used there as a fallback for all *Actions*.
-
-For conditional or complex updates, use `nextStateBy{}` to compute and return the new state.
-
-```kt
-nextStateBy {
-    // ...
-
-    val newCount = ...
-
-    state.copy(count = newCount)
 }
 ```
 
@@ -360,8 +348,6 @@ val store: Store<CounterState, CounterAction, CounterEvent> = Store {
 }
 ```
 
-`error<Exception>{}` can also be written as `anyError{}`.
-
 Errors can be caught not only in the `enter{}` block but also in the `action{}` and `exit{}` blocks.
 In other words, your business logic errors can be handled in the `error{}` block.
 
@@ -418,11 +404,45 @@ state<MyState.Active> {
 }
 ```
 
-If you prefer shorter forms, use `enterAsync{}` / `actionAsync{}` (or `anyActionAsync{}` when using `anyAction{}`).
-
 This pattern lets your *Store* react to external data changes automatically, such as database updates, user preference changes, or network events.
 Coroutines started by `launch{}` are automatically cancelled when the *State* changes to a different *State*, making it easy to manage resources and subscriptions.
 In `action{}`, `launch{}` is tied to the *State* active at action start.
+
+### Cancel Pending Actions
+
+If you need to discard already queued `dispatch()` calls at a specific point, call `cancelPendingActions()` inside `enter{}`, `action{}`, `exit{}`, `error{}`, or inside `transaction{}` from a launched coroutine.
+
+```kt
+state<MyState.Active> {
+    action<MyAction.Finish> {
+        cancelPendingActions()
+        nextState(MyState.Done)
+    }
+}
+```
+
+### Alternative DSL Forms
+
+Some DSL APIs are just alternative forms of existing APIs:
+
+- `anyState{}` is the global form of `state<...>{}` and applies to all *States*.
+- `anyAction{}` is the global form of `action<...>{}` and applies to all *Actions*.
+- `anyError{}` is an alias of `error<Exception>{}`.
+- `enterAsync{}` is shorthand for `enter { launch { ... } }`.
+- `actionAsync{}` is shorthand for `action<...> { launch { ... } }`.
+- `anyActionAsync{}` is shorthand for `anyAction { launch { ... } }`.
+
+Instead of `nextState(...)`, use `nextStateBy{}` when you want to compute and return the next state inside a block.
+
+```kt
+nextStateBy {
+    // ...
+
+    val newCount = ...
+
+    state.copy(count = newCount)
+}
+```
 
 ### Specifying coroutineContext
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -86,15 +86,31 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         )
     }
 
+    private val dispatchScope by lazy {
+        CoroutineScope(
+            coroutineScope.coroutineContext + SupervisorJob(coroutineScope.coroutineContext[Job]),
+        )
+    }
+
     private val mutex = Mutex()
 
     private val stateScopes = mutableMapOf<KClass<out S>, CoroutineScope>()
 
+    private var activeDispatchJob: Job? = null
+
     final override fun dispatch(action: A) {
-        coroutineScope.launch {
+        dispatchScope.launch {
             mutex.withLock {
-                initializeIfNeeded()
-                onActionDispatched(currentState, action)
+                val dispatchJob = coroutineContext[Job]
+                activeDispatchJob = dispatchJob
+                try {
+                    initializeIfNeeded()
+                    onActionDispatched(currentState, action)
+                } finally {
+                    if (activeDispatchJob == dispatchJob) {
+                        activeDispatchJob = null
+                    }
+                }
             }
         }
     }
@@ -243,6 +259,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
+                override suspend fun cancelPendingActions() {
+                    clearPendingDispatchJobs()
+                }
+
                 override suspend fun event(event: E) {
                     emit(event)
                 }
@@ -278,6 +298,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
                 override fun nextStateBy(block: () -> S) {
                     newState = block()
+                }
+
+                override suspend fun cancelPendingActions() {
+                    clearPendingDispatchJobs()
                 }
 
                 override suspend fun event(event: E) {
@@ -348,6 +372,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
+                                override suspend fun cancelPendingActions() {
+                                    clearPendingDispatchJobs()
+                                }
+
                                 override suspend fun event(event: E) {
                                     emit(event)
                                 }
@@ -399,6 +427,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
+                                override suspend fun cancelPendingActions() {
+                                    clearPendingDispatchJobs()
+                                }
+
                                 override suspend fun event(event: E) {
                                     emit(event)
                                 }
@@ -430,6 +462,11 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             onExit.invoke(
                 object : ExitScope<S, E, S> {
                     override val state = state
+
+                    override suspend fun cancelPendingActions() {
+                        clearPendingDispatchJobs()
+                    }
+
                     override suspend fun event(event: E) {
                         emit(event)
                     }
@@ -469,6 +506,10 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
+                override suspend fun cancelPendingActions() {
+                    clearPendingDispatchJobs()
+                }
+
                 override suspend fun event(event: E) {
                     emit(event)
                 }
@@ -483,6 +524,14 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         processMiddleware { beforeEventEmit(state, event) }
         _event.emit(event)
         processMiddleware { afterEventEmit(state, event) }
+    }
+
+    private fun clearPendingDispatchJobs() {
+        val currentJob = activeDispatchJob
+        val dispatchScopeJob = dispatchScope.coroutineContext[Job] ?: return
+        dispatchScopeJob.children
+            .filter { it != currentJob && it.isActive }
+            .forEach { it.cancel() }
     }
 
     private suspend fun processMiddleware(block: suspend Middleware<S, A, E>.() -> Unit) {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -259,7 +259,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override suspend fun cancelPendingActions() {
+                override fun cancelPendingActions() {
                     clearPendingDispatchJobs()
                 }
 
@@ -300,7 +300,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override suspend fun cancelPendingActions() {
+                override fun cancelPendingActions() {
                     clearPendingDispatchJobs()
                 }
 
@@ -372,7 +372,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
-                                override suspend fun cancelPendingActions() {
+                                override fun cancelPendingActions() {
                                     clearPendingDispatchJobs()
                                 }
 
@@ -427,7 +427,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
-                                override suspend fun cancelPendingActions() {
+                                override fun cancelPendingActions() {
                                     clearPendingDispatchJobs()
                                 }
 
@@ -463,7 +463,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 object : ExitScope<S, E, S> {
                     override val state = state
 
-                    override suspend fun cancelPendingActions() {
+                    override fun cancelPendingActions() {
                         clearPendingDispatchJobs()
                     }
 
@@ -506,7 +506,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override suspend fun cancelPendingActions() {
+                override fun cancelPendingActions() {
                     clearPendingDispatchJobs()
                 }
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -40,7 +40,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Cancels actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    suspend fun cancelPendingActions()
+    fun cancelPendingActions()
 
     /**
      * Emits an event from the enter handler.
@@ -121,7 +121,7 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
              * Cancels actions that are already queued behind the currently executing store work.
              * The action/transaction currently in progress keeps running.
              */
-            suspend fun cancelPendingActions()
+            fun cancelPendingActions()
 
             /**
              * Emits an event from the transaction.
@@ -149,7 +149,7 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
      * Cancels actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    suspend fun cancelPendingActions()
+    fun cancelPendingActions()
 
     /**
      * Emits an event from the exit handler.
@@ -196,7 +196,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * Cancels actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    suspend fun cancelPendingActions()
+    fun cancelPendingActions()
 
     /**
      * Emits an event from the action handler.
@@ -287,7 +287,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
              * Cancels actions that are already queued behind the currently executing store work.
              * The action/transaction currently in progress keeps running.
              */
-            suspend fun cancelPendingActions()
+            fun cancelPendingActions()
 
             /**
              * Emits an event from the transaction.
@@ -336,7 +336,7 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
      * Cancels actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    suspend fun cancelPendingActions()
+    fun cancelPendingActions()
 
     /**
      * Emits an event from the error handler.

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -37,6 +37,12 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
+     * Cancels actions that are already queued behind the currently executing store work.
+     * The action/transaction currently in progress keeps running.
+     */
+    suspend fun cancelPendingActions()
+
+    /**
      * Emits an event from the enter handler.
      * Use this to communicate with the outside world about important occurrences.
      *
@@ -112,6 +118,12 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
+             * Cancels actions that are already queued behind the currently executing store work.
+             * The action/transaction currently in progress keeps running.
+             */
+            suspend fun cancelPendingActions()
+
+            /**
              * Emits an event from the transaction.
              * Use this to communicate with the outside world about important occurrences.
              *
@@ -132,6 +144,12 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
      * The current state that's being exited
      */
     val state: S2
+
+    /**
+     * Cancels actions that are already queued behind the currently executing store work.
+     * The action/transaction currently in progress keeps running.
+     */
+    suspend fun cancelPendingActions()
 
     /**
      * Emits an event from the exit handler.
@@ -173,6 +191,12 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * @param block A function that computes and returns the new state
      */
     fun nextStateBy(block: () -> S)
+
+    /**
+     * Cancels actions that are already queued behind the currently executing store work.
+     * The action/transaction currently in progress keeps running.
+     */
+    suspend fun cancelPendingActions()
 
     /**
      * Emits an event from the action handler.
@@ -260,6 +284,12 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
+             * Cancels actions that are already queued behind the currently executing store work.
+             * The action/transaction currently in progress keeps running.
+             */
+            suspend fun cancelPendingActions()
+
+            /**
              * Emits an event from the transaction.
              * Use this to communicate with the outside world about important occurrences.
              *
@@ -301,6 +331,12 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
      * @param block A function that computes and returns the new state
      */
     fun nextStateBy(block: () -> S)
+
+    /**
+     * Cancels actions that are already queued behind the currently executing store work.
+     * The action/transaction currently in progress keeps running.
+     */
+    suspend fun cancelPendingActions()
 
     /**
      * Emits an event from the error handler.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
@@ -1,0 +1,112 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorePendingActionCancellationTest {
+
+    sealed interface AppState : State {
+        data class Active(val value: Int = 0) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object HoldAndCancel : AppAction
+        data object LaunchTransactionAndCancel : AppAction
+        data object Increment : AppAction
+    }
+
+    private fun createTestStore(
+        testDispatcher: TestDispatcher,
+        onHoldAndCancelStarted: CompletableDeferred<Unit>? = null,
+        onHoldAndCancelCompleted: CompletableDeferred<Unit>? = null,
+        onTransactionStarted: CompletableDeferred<Unit>? = null,
+        onTransactionCompleted: CompletableDeferred<Unit>? = null,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(AppState.Active()) {
+            coroutineContext(testDispatcher)
+
+            state<AppState.Active> {
+                action<AppAction.HoldAndCancel>(testDispatcher) {
+                    onHoldAndCancelStarted?.complete(Unit)
+                    delay(100)
+                    cancelPendingActions()
+                    onHoldAndCancelCompleted?.complete(Unit)
+                    nextState(state.copy(value = state.value + 100))
+                }
+
+                action<AppAction.LaunchTransactionAndCancel>(testDispatcher) {
+                    launch(testDispatcher) {
+                        transaction(testDispatcher) {
+                            onTransactionStarted?.complete(Unit)
+                            delay(100)
+                            cancelPendingActions()
+                            onTransactionCompleted?.complete(Unit)
+                            nextState(state.copy(value = state.value + 100))
+                        }
+                    }
+                }
+
+                action<AppAction.Increment>(testDispatcher) {
+                    nextState(state.copy(value = state.value + 1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun cancelPendingActions_inAction_skipsQueuedDispatches() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val actionStarted = CompletableDeferred<Unit>()
+        val actionCompleted = CompletableDeferred<Unit>()
+        val store = createTestStore(
+            testDispatcher = testDispatcher,
+            onHoldAndCancelStarted = actionStarted,
+            onHoldAndCancelCompleted = actionCompleted,
+        )
+
+        store.dispatch(AppAction.HoldAndCancel)
+        runCurrent()
+        actionStarted.await()
+
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(true, actionCompleted.isCompleted, "The running action should not cancel itself")
+        assertEquals(AppState.Active(value = 100), store.currentState)
+    }
+
+    @Test
+    fun cancelPendingActions_inTransaction_skipsQueuedDispatches() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val transactionStarted = CompletableDeferred<Unit>()
+        val transactionCompleted = CompletableDeferred<Unit>()
+        val store = createTestStore(
+            testDispatcher = testDispatcher,
+            onTransactionStarted = transactionStarted,
+            onTransactionCompleted = transactionCompleted,
+        )
+
+        store.dispatch(AppAction.LaunchTransactionAndCancel)
+        runCurrent()
+        transactionStarted.await()
+
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(true, transactionCompleted.isCompleted, "The running transaction should complete")
+        assertEquals(AppState.Active(value = 100), store.currentState)
+    }
+}


### PR DESCRIPTION
## Summary
- Add cancelPendingActions() to store handler scopes and transaction scopes.
- Keep plain launch scopes excluded from this API.
- Route dispatch processing through a dedicated dispatch scope.
- Cancel queued dispatch jobs while keeping the running dispatch alive.
- Add common tests for action and transaction cancellation behavior.
- Verify the running handler still completes after cancellation.
- Add a README section for canceling pending actions.
- Document alternative DSL forms in a dedicated section.

## Verification
- ./gradlew :tart-core:jvmTest