### PR TITLE
Add pending action policy and clear pending actions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ By combining Tart with Kotlin `sealed class`/`sealed interface`, you can model e
   - [Multiple states and transitions](#multiple-states-and-transitions)
   - [Error handling](#error-handling)
   - [Asynchronous Work](#asynchronous-work)
-  - [Cancel Pending Actions](#cancel-pending-actions)
+  - [Clear Pending Actions](#clear-pending-actions)
   - [Alternative DSL Forms](#alternative-dsl-forms)
   - [Specifying coroutineContext](#specifying-coroutinecontext)
     - [Specifying CoroutineDispatchers](#specifying-coroutinedispatchers)
@@ -408,18 +408,20 @@ This pattern lets your *Store* react to external data changes automatically, suc
 Coroutines started by `launch{}` are automatically cancelled when the *State* changes to a different *State*, making it easy to manage resources and subscriptions.
 In `action{}`, `launch{}` is tied to the *State* active at action start.
 
-### Cancel Pending Actions
+### Clear Pending Actions
 
-If you need to discard already queued `dispatch()` calls at a specific point, call `cancelPendingActions()` inside `enter{}`, `action{}`, `exit{}`, `error{}`, or inside `transaction{}` from a launched coroutine.
+By default, Tart clears already queued actions when the store exits the current state and enters a different state variant.
+To keep queued actions across state exits, set `pendingActionPolicy(PendingActionPolicy.KEEP)`.
 
 ```kt
-state<MyState.Active> {
-    action<MyAction.Finish> {
-        cancelPendingActions()
-        nextState(MyState.Done)
-    }
+val store = Store<MyState, MyAction, MyEvent>(MyState.Initial) {
+    // ...
+
+    pendingActionPolicy(PendingActionPolicy.KEEP)
 }
 ```
+
+Regardless of the configured `PendingActionPolicy`, you can still discard already queued actions at a specific point by calling `clearPendingActions()` inside `enter{}`, `action{}`, `exit{}`, `error{}`, or inside `transaction{}` from a launched coroutine.
 
 ### Alternative DSL Forms
 

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/PendingActionPolicy.kt
@@ -1,0 +1,17 @@
+package io.yumemi.tart.core
+
+/**
+ * Controls how queued actions are handled when the store exits the current state.
+ */
+enum class PendingActionPolicy {
+    /**
+     * Clears queued actions after a transition to a different state variant is committed.
+     * The currently running store work keeps running.
+     */
+    CLEAR_ON_STATE_EXIT,
+
+    /**
+     * Keeps queued actions unless they are cleared explicitly from DSL scopes.
+     */
+    KEEP,
+}

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreBuilder.kt
@@ -13,6 +13,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeCoroutineContext: CoroutineContext = EmptyCoroutineContext + Dispatchers.Default
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
     private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
+    private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.CLEAR_ON_STATE_EXIT
     private var storeMiddlewares: MutableList<Middleware<S, A, E>> = mutableListOf()
 
     /**
@@ -49,6 +50,15 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
      */
     fun exceptionHandler(exceptionHandler: ExceptionHandler) {
         storeExceptionHandler = exceptionHandler
+    }
+
+    /**
+     * Sets how queued actions are handled when the store exits the current state.
+     *
+     * @param policy The pending action policy to use
+     */
+    fun pendingActionPolicy(policy: PendingActionPolicy) {
+        storePendingActionPolicy = policy
     }
 
     /**
@@ -342,6 +352,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val coroutineContext: CoroutineContext = storeCoroutineContext
             override val stateSaver: StateSaver<S> = storeStateSaver
             override val exceptionHandler: ExceptionHandler = storeExceptionHandler
+            override val pendingActionPolicy: PendingActionPolicy = storePendingActionPolicy
             override val middlewares: List<Middleware<S, A, E>> = storeMiddlewares
             override val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreImpl.kt
@@ -68,6 +68,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val exceptionHandler: ExceptionHandler
 
+    protected abstract val pendingActionPolicy: PendingActionPolicy
+
     protected abstract val middlewares: List<Middleware<S, A, E>>
 
     protected abstract val onEnter: suspend EnterScope<S, A, E, S>.() -> Unit
@@ -169,6 +171,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
             if (state != nextState) {
                 processStateChange(state, nextState)
+                if (state::class != nextState::class) {
+                    clearPendingActionsOnStateExitIfNeeded()
+                }
             }
 
             if (state::class != nextState::class) {
@@ -188,6 +193,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
             if (state != nextState) {
                 processStateChange(state, nextState)
+                if (state::class != nextState::class) {
+                    clearPendingActionsOnStateExitIfNeeded()
+                }
             }
 
             if (state::class != nextState::class) {
@@ -209,6 +217,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
             if (state != nextState) {
                 processStateChange(state, nextState)
+                if (state::class != nextState::class) {
+                    clearPendingActionsOnStateExitIfNeeded()
+                }
             }
 
             if (state::class != nextState::class) {
@@ -233,6 +244,9 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
             if (state != nextState) {
                 processStateChange(state, nextState)
+                if (state::class != nextState::class) {
+                    clearPendingActionsOnStateExitIfNeeded()
+                }
             }
 
             if (state::class != nextState::class) {
@@ -259,7 +273,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override fun cancelPendingActions() {
+                override fun clearPendingActions() {
                     clearPendingDispatchJobs()
                 }
 
@@ -300,7 +314,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override fun cancelPendingActions() {
+                override fun clearPendingActions() {
                     clearPendingDispatchJobs()
                 }
 
@@ -372,7 +386,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
-                                override fun cancelPendingActions() {
+                                override fun clearPendingActions() {
                                     clearPendingDispatchJobs()
                                 }
 
@@ -427,7 +441,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                                     newState = block()
                                 }
 
-                                override fun cancelPendingActions() {
+                                override fun clearPendingActions() {
                                     clearPendingDispatchJobs()
                                 }
 
@@ -463,7 +477,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                 object : ExitScope<S, E, S> {
                     override val state = state
 
-                    override fun cancelPendingActions() {
+                    override fun clearPendingActions() {
                         clearPendingDispatchJobs()
                     }
 
@@ -506,7 +520,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
                     newState = block()
                 }
 
-                override fun cancelPendingActions() {
+                override fun clearPendingActions() {
                     clearPendingDispatchJobs()
                 }
 
@@ -524,6 +538,12 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         processMiddleware { beforeEventEmit(state, event) }
         _event.emit(event)
         processMiddleware { afterEventEmit(state, event) }
+    }
+
+    private fun clearPendingActionsOnStateExitIfNeeded() {
+        if (pendingActionPolicy == PendingActionPolicy.CLEAR_ON_STATE_EXIT) {
+            clearPendingDispatchJobs()
+        }
     }
 
     private fun clearPendingDispatchJobs() {

--- a/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
+++ b/tart-core/src/commonMain/kotlin/io/yumemi/tart/core/StoreScope.kt
@@ -37,10 +37,10 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Cancels actions that are already queued behind the currently executing store work.
+     * Clears actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    fun cancelPendingActions()
+    fun clearPendingActions()
 
     /**
      * Emits an event from the enter handler.
@@ -118,10 +118,10 @@ interface EnterScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
-             * Cancels actions that are already queued behind the currently executing store work.
+             * Clears actions that are already queued behind the currently executing store work.
              * The action/transaction currently in progress keeps running.
              */
-            fun cancelPendingActions()
+            fun clearPendingActions()
 
             /**
              * Emits an event from the transaction.
@@ -146,10 +146,10 @@ interface ExitScope<S : State, E : Event, S2 : S> : StoreScope {
     val state: S2
 
     /**
-     * Cancels actions that are already queued behind the currently executing store work.
+     * Clears actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    fun cancelPendingActions()
+    fun clearPendingActions()
 
     /**
      * Emits an event from the exit handler.
@@ -193,10 +193,10 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Cancels actions that are already queued behind the currently executing store work.
+     * Clears actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    fun cancelPendingActions()
+    fun clearPendingActions()
 
     /**
      * Emits an event from the action handler.
@@ -284,10 +284,10 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
             fun nextStateBy(block: () -> S)
 
             /**
-             * Cancels actions that are already queued behind the currently executing store work.
+             * Clears actions that are already queued behind the currently executing store work.
              * The action/transaction currently in progress keeps running.
              */
-            fun cancelPendingActions()
+            fun clearPendingActions()
 
             /**
              * Emits an event from the transaction.
@@ -333,10 +333,10 @@ interface ErrorScope<S : State, E : Event, S2 : S, T : Throwable> : StoreScope {
     fun nextStateBy(block: () -> S)
 
     /**
-     * Cancels actions that are already queued behind the currently executing store work.
+     * Clears actions that are already queued behind the currently executing store work.
      * The action/transaction currently in progress keeps running.
      */
-    fun cancelPendingActions()
+    fun clearPendingActions()
 
     /**
      * Emits an event from the error handler.

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionCancellationTest.kt
@@ -33,12 +33,13 @@ class StorePendingActionCancellationTest {
     ): Store<AppState, AppAction, Nothing> {
         return Store(AppState.Active()) {
             coroutineContext(testDispatcher)
+            pendingActionPolicy(PendingActionPolicy.KEEP)
 
             state<AppState.Active> {
                 action<AppAction.HoldAndCancel>(testDispatcher) {
                     onHoldAndCancelStarted?.complete(Unit)
                     delay(100)
-                    cancelPendingActions()
+                    clearPendingActions()
                     onHoldAndCancelCompleted?.complete(Unit)
                     nextState(state.copy(value = state.value + 100))
                 }
@@ -48,7 +49,7 @@ class StorePendingActionCancellationTest {
                         transaction(testDispatcher) {
                             onTransactionStarted?.complete(Unit)
                             delay(100)
-                            cancelPendingActions()
+                            clearPendingActions()
                             onTransactionCompleted?.complete(Unit)
                             nextState(state.copy(value = state.value + 100))
                         }

--- a/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionPolicyTest.kt
+++ b/tart-core/src/commonTest/kotlin/io/yumemi/tart/core/StorePendingActionPolicyTest.kt
@@ -1,0 +1,137 @@
+package io.yumemi.tart.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StorePendingActionPolicyTest {
+
+    sealed interface AppState : State {
+        data object Initial : AppState
+        data class Active(val value: Int = 0) : AppState
+    }
+
+    sealed interface AppAction : Action {
+        data object EnterActiveAfterDelay : AppAction
+        data object UpdateInPlaceAfterDelay : AppAction
+        data object Increment : AppAction
+    }
+
+    private fun createStore(
+        testDispatcher: TestDispatcher,
+        pendingActionPolicy: PendingActionPolicy = PendingActionPolicy.CLEAR_ON_STATE_EXIT,
+        onTransitionStarted: CompletableDeferred<Unit>? = null,
+        onTransitionCompleted: CompletableDeferred<Unit>? = null,
+    ): Store<AppState, AppAction, Nothing> {
+        return Store(AppState.Initial) {
+            coroutineContext(testDispatcher)
+            pendingActionPolicy(pendingActionPolicy)
+
+            state<AppState.Initial> {
+                action<AppAction.EnterActiveAfterDelay>(testDispatcher) {
+                    onTransitionStarted?.complete(Unit)
+                    delay(100)
+                    onTransitionCompleted?.complete(Unit)
+                    nextState(AppState.Active())
+                }
+            }
+
+            state<AppState.Active> {
+                action<AppAction.UpdateInPlaceAfterDelay>(testDispatcher) {
+                    delay(100)
+                    nextState(state.copy(value = state.value + 100))
+                }
+
+                action<AppAction.Increment>(testDispatcher) {
+                    nextState(state.copy(value = state.value + 1))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun clearOnStateExit_dropsQueuedActionsAfterStateTransition() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val transitionStarted = CompletableDeferred<Unit>()
+        val transitionCompleted = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            onTransitionStarted = transitionStarted,
+            onTransitionCompleted = transitionCompleted,
+        )
+
+        store.dispatch(AppAction.EnterActiveAfterDelay)
+        runCurrent()
+        transitionStarted.await()
+
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(true, transitionCompleted.isCompleted, "The running transition should complete")
+        assertEquals(AppState.Active(value = 0), store.currentState)
+    }
+
+    @Test
+    fun keep_preservesQueuedActionsAfterStateTransition() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val transitionStarted = CompletableDeferred<Unit>()
+        val store = createStore(
+            testDispatcher = testDispatcher,
+            pendingActionPolicy = PendingActionPolicy.KEEP,
+            onTransitionStarted = transitionStarted,
+        )
+
+        store.dispatch(AppAction.EnterActiveAfterDelay)
+        runCurrent()
+        transitionStarted.await()
+
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(AppState.Active(value = 2), store.currentState)
+    }
+
+    @Test
+    fun clearOnStateExit_keepsQueuedActionsForSameStateUpdates() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val inPlaceUpdateStarted = CompletableDeferred<Unit>()
+        val store = Store<AppState, AppAction, Nothing>(AppState.Active()) {
+            coroutineContext(testDispatcher)
+
+            state<AppState.Active> {
+                action<AppAction.UpdateInPlaceAfterDelay>(testDispatcher) {
+                    inPlaceUpdateStarted.complete(Unit)
+                    delay(100)
+                    nextState(state.copy(value = state.value + 100))
+                }
+
+                action<AppAction.Increment>(testDispatcher) {
+                    nextState(state.copy(value = state.value + 1))
+                }
+            }
+        }
+
+        store.dispatch(AppAction.UpdateInPlaceAfterDelay)
+        runCurrent()
+        inPlaceUpdateStarted.await()
+
+        store.dispatch(AppAction.Increment)
+        store.dispatch(AppAction.Increment)
+
+        advanceUntilIdle()
+
+        assertEquals(AppState.Active(value = 102), store.currentState)
+    }
+}


### PR DESCRIPTION
## Summary
- Add PendingActionPolicy with CLEAR_ON_STATE_EXIT and KEEP.
- Default to clearing queued actions after a committed state-class transition.
- Rename the DSL API to clearPendingActions().
- Keep explicit queue clearing available regardless of the configured policy.
- Add tests for auto-clear, KEEP, and same-state updates.
- Update the README to describe the new default behavior.

## Verification
- ./gradlew :tart-core:jvmTest