### PR TITLE
Refine ViewStore state holder behavior

### DIFF
--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -3,9 +3,10 @@ package io.github.komakt.koma.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State as ComposeState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import io.github.komakt.koma.core.Action
 import io.github.komakt.koma.core.Event
@@ -16,30 +17,41 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 
 /**
- * Compose-friendly wrapper around a [Store] snapshot.
+ * Compose-friendly state holder for a [Store].
  *
- * It exposes the latest state, a dispatch function, and access to the Store's event stream.
+ * A [ViewStore] is tied to a Store instance and exposes its latest state, a dispatch function,
+ * and access to the Store's event stream.
  *
- * @param state The current state
+ * When created by [rememberViewStore], the same [ViewStore] instance is retained while the
+ * underlying Store instance remains the same. Its [state] property always reads the latest
+ * collected Store state from Compose-managed state.
+ *
+ * The secondary constructor that accepts a plain [state] creates a standalone holder with a fixed
+ * initial value, which is useful for previews, tests, and other non-Store-backed usage.
+ *
+ * @param stateRef Compose state that always holds the latest Store state
  * @param dispatch Function to dispatch actions
  * @param eventFlow Flow used to receive one-off events
  */
 @Suppress("unused")
 @Stable
-class ViewStore<S : State, A : Action, E : Event>(
-    val state: S,
+class ViewStore<S : State, A : Action, E : Event> internal constructor(
+    private val stateRef: ComposeState<S>,
     val dispatch: (A) -> Unit = {},
     @PublishedApi internal val eventFlow: Flow<E> = emptyFlow(),
 ) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is ViewStore<*, *, *>) return false
-        return this.state == other.state
-    }
+    constructor(
+        state: S,
+        dispatch: (A) -> Unit = {},
+        eventFlow: Flow<E> = emptyFlow(),
+    ) : this(
+        stateRef = mutableStateOf(state),
+        dispatch = dispatch,
+        eventFlow = eventFlow,
+    )
 
-    override fun hashCode(): Int {
-        return state.hashCode()
-    }
+    val state: S
+        get() = stateRef.value
 
     /**
      * Invokes [block] only when the current [state] is of type [S2].
@@ -77,7 +89,7 @@ class ViewStore<S : State, A : Action, E : Event>(
 }
 
 /**
- * Remembers a [Store], collects its state as Compose state, and exposes it as a [ViewStore].
+ * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
  * Collecting [Store.state] starts the Store immediately.
  * Because [ViewStore.handle] starts collecting later from a [LaunchedEffect], startup events such
@@ -85,11 +97,14 @@ class ViewStore<S : State, A : Action, E : Event>(
  * composition begin observing them.
  *
  * The [store] lambda is used only when a new remembered Store must be created for [key].
+ * For a given remembered Store instance, this function returns the same [ViewStore] instance across
+ * recompositions. A new [ViewStore] is created only when a new Store instance is remembered for
+ * [key].
  *
  * @param key Key used to remember and retain the Store instance
  * @param autoClose Whether to close the Store when the composable leaves the composition
  * @param store Composable function to create the source Store instance
- * @return A ViewStore instance
+ * @return A ViewStore state holder backed by the remembered Store
  */
 @Suppress("unused")
 @Composable
@@ -103,7 +118,7 @@ fun <S : State, A : Action, E : Event> rememberViewStore(key: Any? = null, autoC
     }
     val rememberedStore = holder.value ?: store().also { holder.value = it }
 
-    val state by rememberedStore.state.collectAsState()
+    val state = rememberedStore.state.collectAsState()
 
     DisposableEffect(rememberedStore) {
         onDispose {
@@ -113,9 +128,9 @@ fun <S : State, A : Action, E : Event> rememberViewStore(key: Any? = null, autoC
         }
     }
 
-    return remember(state) {
+    return remember(rememberedStore) {
         ViewStore(
-            state = state,
+            stateRef = state,
             dispatch = rememberedStore::dispatch,
             eventFlow = rememberedStore.event,
         )

--- a/koma-compose/src/commonTest/kotlin/io/github/komakt/koma/compose/ViewStoreTest.kt
+++ b/koma-compose/src/commonTest/kotlin/io/github/komakt/koma/compose/ViewStoreTest.kt
@@ -1,25 +1,21 @@
 package io.github.komakt.koma.compose
 
+import androidx.compose.runtime.mutableStateOf
 import io.github.komakt.koma.core.State
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
-@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class ViewStoreTest {
-
-    private val testDispatcher = UnconfinedTestDispatcher()
-
     @Test
-    fun viewStore_equalsWorksCorrectly() = runTest(testDispatcher) {
-        val viewStore1 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(10))
-        val viewStore2 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(10))
-        val viewStore3 = ViewStore<CounterState, Nothing, Nothing>(state = CounterState(20))
+    fun viewStore_readsLatestValueFromStateRef() {
+        val stateRef = mutableStateOf(CounterState(10))
+        val viewStore = ViewStore<CounterState, Nothing, Nothing>(stateRef = stateRef)
 
-        assertEquals(viewStore1, viewStore2)
-        assertNotEquals(viewStore1, viewStore3)
+        assertEquals(CounterState(10), viewStore.state)
+
+        stateRef.value = CounterState(20)
+
+        assertEquals(CounterState(20), viewStore.state)
     }
 }
 

--- a/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
+++ b/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.withRunningRecomposer
 import io.github.komakt.koma.core.Action
 import io.github.komakt.koma.core.Event
@@ -20,6 +21,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -87,6 +91,152 @@ class ViewStoreJvmTest {
                 assertEquals(listOf<UiAction>(UiAction.Increment), store.dispatchedActions)
             },
         )
+    }
+
+    @Test
+    fun rememberViewStore_keepsSameInstanceWhileStateUpdates() = runTest(testDispatcher) {
+        val store = TestStore(UiState.Ready(1))
+        lateinit var viewStore: ViewStore<UiState, UiAction, UiEvent>
+
+        withComposition(
+            content = {
+                viewStore = rememberViewStore { store }
+            },
+            afterSetContent = {
+                val initialViewStore = viewStore
+                store.state.value = UiState.Ready(2)
+                testScheduler.runCurrent()
+
+                assertSame(initialViewStore, viewStore)
+                assertEquals(UiState.Ready(2), viewStore.state)
+            },
+        )
+    }
+
+    @Test
+    fun rememberViewStore_recreatesWhenKeyChangesEvenIfStateIsEqual() = runTest(testDispatcher) {
+        val firstStore = TestStore(UiState.Loading)
+        val secondStore = TestStore(UiState.Loading)
+        val frameClock = BroadcastFrameClock()
+        var frameTimeNanos = 0L
+        var key = "first"
+        lateinit var latestViewStore: ViewStore<UiState, UiAction, UiEvent>
+
+        suspend fun pumpFrame() {
+            testScheduler.runCurrent()
+            frameTimeNanos += 16_000_000L
+            frameClock.sendFrame(frameTimeNanos)
+            testScheduler.runCurrent()
+        }
+
+        withContext(frameClock) {
+            withRunningRecomposer { recomposer ->
+                val composition = Composition(NoOpApplier(), recomposer)
+                try {
+                    composition.setContent {
+                        latestViewStore = rememberViewStore(key = key) {
+                            if (key == "first") firstStore else secondStore
+                        }
+                    }
+                    repeat(2) { pumpFrame() }
+                    val initialViewStore = latestViewStore
+
+                    key = "second"
+                    composition.setContent {
+                        latestViewStore = rememberViewStore(key = key) {
+                            if (key == "first") firstStore else secondStore
+                        }
+                    }
+                    repeat(2) { pumpFrame() }
+
+                    assertNotSame(initialViewStore, latestViewStore)
+
+                    latestViewStore.dispatch(UiAction.Increment)
+
+                    assertTrue(firstStore.dispatchedActions.isEmpty())
+                    assertEquals(listOf<UiAction>(UiAction.Increment), secondStore.dispatchedActions)
+                } finally {
+                    composition.dispose()
+                    pumpFrame()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun rememberViewStore_capturedCallbackReadsLatestState() = runTest(testDispatcher) {
+        val store = TestStore(UiState.Loading)
+        lateinit var canHide: () -> Boolean
+
+        withComposition(
+            content = {
+                val viewStore = rememberViewStore { store }
+                canHide = remember {
+                    {
+                        viewStore.state !is UiState.Busy
+                    }
+                }
+            },
+            afterSetContent = {
+                assertTrue(canHide())
+                store.state.value = UiState.Busy
+            },
+        )
+
+        assertFalse(canHide())
+    }
+
+    @Test
+    fun childThatDoesNotReadState_isSkippedOnStateUpdate() = runTest(testDispatcher) {
+        val store = TestStore(UiState.Ready(1))
+        var childCompositions = 0
+
+        @Composable
+        fun Child(viewStore: ViewStore<UiState, UiAction, UiEvent>) {
+            childCompositions++
+        }
+
+        withComposition(
+            content = {
+                val viewStore = rememberViewStore { store }
+                Child(viewStore)
+            },
+            afterSetContent = {
+                assertEquals(1, childCompositions)
+
+                store.state.value = UiState.Ready(2)
+                testScheduler.runCurrent()
+            },
+        )
+
+        assertEquals(1, childCompositions)
+    }
+
+    @Test
+    fun childThatReadsViewStoreState_isStillSkippedOnStateUpdate() = runTest(testDispatcher) {
+        val store = TestStore(UiState.Ready(1))
+        var childCompositions = 0
+
+        @Composable
+        fun Child(viewStore: ViewStore<UiState, UiAction, UiEvent>) {
+            viewStore.state
+            childCompositions++
+        }
+
+        withComposition(
+            content = {
+                val viewStore = rememberViewStore { store }
+                Child(viewStore)
+            },
+            afterSetContent = {
+                assertEquals(1, childCompositions)
+
+                store.state.value = UiState.Ready(2)
+                testScheduler.runCurrent()
+            },
+        )
+
+        assertEquals(1, childCompositions)
     }
 
     @Test
@@ -237,6 +387,7 @@ class ViewStoreJvmTest {
 
 private sealed interface UiState : State {
     data object Loading : UiState
+    data object Busy : UiState
     data class Ready(val value: Int) : UiState
 }
 


### PR DESCRIPTION
## Summary
- Convert ViewStore into a Store-backed state holder that keeps the same instance while exposing the latest collected state.
- Update KDoc and tests to document and verify the new ViewStore semantics, including key changes and captured callbacks.
- Add characterization tests around the current recomposition behavior when child composables read ViewStore state.

## Why
- Clarify how ViewStore behaves after switching from snapshot-style wrapping to a holder-style API.
- Preserve callback access to the latest state while documenting the current Compose behavior more explicitly.

## Verification
- JAVA_HOME=/Users/h_kusu/Library/Java/JavaVirtualMachines/AndroidStudio/Contents/Home ./gradlew :koma-compose:jvmTest