### PR TITLE
Name lambda parameters in public API function types

### DIFF
--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.filter
 @Stable
 class ViewStore<S : State, A : Action, E : Event>(
     val state: S,
-    val dispatch: (A) -> Unit = {},
+    val dispatch: (action: A) -> Unit = {},
     @PublishedApi internal val eventFlow: Flow<E> = emptyFlow(),
 ) {
     override fun equals(other: Any?): Boolean {
@@ -67,7 +67,7 @@ class ViewStore<S : State, A : Action, E : Event>(
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified E2 : E> handle(crossinline block: ViewStore<S, A, E>.(E2) -> Unit) {
+    inline fun <reified E2 : E> handle(crossinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
         LaunchedEffect(eventFlow) {
             eventFlow.filter { it is E2 }.collect {
                 block(this@ViewStore, it as E2)

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
@@ -47,7 +47,7 @@ interface ExceptionHandler {
 /**
  * Creates an [ExceptionHandler] from a single callback.
  */
-fun ExceptionHandler(block: (Throwable) -> Unit) = object : ExceptionHandler {
+fun ExceptionHandler(block: (error: Throwable) -> Unit) = object : ExceptionHandler {
     override fun handle(error: Throwable) {
         block.invoke(error)
     }

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Plugin.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Plugin.kt
@@ -49,10 +49,10 @@ interface Plugin<S : State, A : Action, E : Event> {
  * @param onEvent Function called after an event is emitted
  */
 fun <S : State, A : Action, E : Event> Plugin(
-    onStart: suspend PluginScope<S, A>.(S) -> Unit = {},
-    onAction: suspend PluginScope<S, A>.(S, A) -> Unit = { _, _ -> },
-    onState: suspend PluginScope<S, A>.(S, S) -> Unit = { _, _ -> },
-    onEvent: suspend PluginScope<S, A>.(S, E) -> Unit = { _, _ -> },
+    onStart: suspend PluginScope<S, A>.(state: S) -> Unit = {},
+    onAction: suspend PluginScope<S, A>.(state: S, action: A) -> Unit = { _, _ -> },
+    onState: suspend PluginScope<S, A>.(prevState: S, state: S) -> Unit = { _, _ -> },
+    onEvent: suspend PluginScope<S, A>.(state: S, event: E) -> Unit = { _, _ -> },
 ) = object : Plugin<S, A, E> {
     override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
         scope.onStart(state)

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StateSaver.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StateSaver.kt
@@ -39,7 +39,7 @@ interface StateSaver<S : State> {
 /**
  * Creates a [StateSaver] from save and restore lambdas.
  */
-fun <S : State> StateSaver(save: (S) -> Unit, restore: () -> S?) = object : StateSaver<S> {
+fun <S : State> StateSaver(save: (state: S) -> Unit, restore: () -> S?) = object : StateSaver<S> {
     override fun save(state: S) {
         save.invoke(state)
     }

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Store.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Store.kt
@@ -78,7 +78,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      *
      * @param state Callback called when the state changes
      */
-    fun collectState(state: (S) -> Unit)
+    fun collectState(state: (state: S) -> Unit)
 
     /**
      * Collects one-off events using a callback.
@@ -99,7 +99,7 @@ interface Store<S : State, A : Action, E : Event> : AutoCloseable {
      *
      * @param event Callback called when an event is emitted
      */
-    fun collectEvent(event: (E) -> Unit)
+    fun collectEvent(event: (event: E) -> Unit)
 
     /**
      * Cancels the Store and releases its resources.

--- a/koma-message/src/commonMain/kotlin/io/github/komakt/koma/message/Plugin.kt
+++ b/koma-message/src/commonMain/kotlin/io/github/komakt/koma/message/Plugin.kt
@@ -19,7 +19,7 @@ import io.github.komakt.koma.core.State
  * @param block Function to process received messages with [PluginLaunchScope] as receiver
  * @return Plugin that processes shared messages
  */
-fun <S : State, A : Action, E : Event> receiveMessages(block: suspend PluginLaunchScope<S, A>.(Message) -> Unit): Plugin<S, A, E> {
+fun <S : State, A : Action, E : Event> receiveMessages(block: suspend PluginLaunchScope<S, A>.(message: Message) -> Unit): Plugin<S, A, E> {
     return object : Plugin<S, A, E> {
         override suspend fun onStart(scope: PluginScope<S, A>, state: S) {
             scope.launch {


### PR DESCRIPTION
## Summary

Public-facing function-type parameters had no parameter names, so callers had to infer them from KDoc. The worst case was `Plugin()`'s `onState: (S, S) -> Unit` — both arguments share the same type, making it impossible to tell `prevState` and `state` apart at a glance.

This PR names the eleven public lambda types so IDE hover, autocomplete and Dokka output can surface them. Names align with the existing `Plugin` / `ExceptionHandler` interface contracts (`prevState`, `state`, `action`, `event`, `error`, `message`).

## Changes

| Place | Before | After |
|---|---|---|
| `Plugin()` factory `onStart` | `(S) -> Unit` | `(state: S) -> Unit` |
| `Plugin()` factory `onAction` | `(S, A) -> Unit` | `(state: S, action: A) -> Unit` |
| `Plugin()` factory `onState` | `(S, S) -> Unit` | `(prevState: S, state: S) -> Unit` |
| `Plugin()` factory `onEvent` | `(S, E) -> Unit` | `(state: S, event: E) -> Unit` |
| `Store.collectState` | `(S) -> Unit` | `(state: S) -> Unit` |
| `Store.collectEvent` | `(E) -> Unit` | `(event: E) -> Unit` |
| `StateSaver(save, …)` | `(S) -> Unit` | `(state: S) -> Unit` |
| `ExceptionHandler(block)` | `(Throwable) -> Unit` | `(error: Throwable) -> Unit` |
| `receiveMessages(block)` | `…(Message) -> Unit` | `…(message: Message) -> Unit` |
| `ViewStore.handle` | `…(E2) -> Unit` | `…(event: E2) -> Unit` |
| `ViewStore` ctor `dispatch` | `(A) -> Unit` | `(action: A) -> Unit` |

## Compatibility

Source-compatible. Callers can keep using `it` for single-arg lambdas or pick any parameter names they like — the declared names only surface in tooling.

## Test plan

- [ ] Verify IDE hover/autocomplete shows the new parameter names
- [ ] Verify existing tests pass