### PR TITLE
Fix stale callback handling in ViewStore

### DIFF
--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -3,11 +3,11 @@ package io.github.komakt.koma.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State as ComposeState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import io.github.komakt.koma.core.Action
 import io.github.komakt.koma.core.Event
 import io.github.komakt.koma.core.State
@@ -15,6 +15,7 @@ import io.github.komakt.koma.core.Store
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
+import androidx.compose.runtime.State as ComposeState
 
 /**
  * Compose-friendly state holder for a [Store].
@@ -79,10 +80,12 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified E2 : E> handle(crossinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
+    inline fun <reified E2 : E> handle(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
+        val currentViewStore = rememberUpdatedState(this)
+        val currentBlock = rememberUpdatedState(block)
         LaunchedEffect(eventFlow) {
             eventFlow.filter { it is E2 }.collect {
-                block(this@ViewStore, it as E2)
+                currentBlock.value(currentViewStore.value, it as E2)
             }
         }
     }

--- a/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
+++ b/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
@@ -76,6 +76,60 @@ class ViewStoreJvmTest {
     }
 
     @Test
+    fun handle_usesLatestViewStoreAndLambdaAfterRecomposition() = runTest(testDispatcher) {
+        val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
+        val handled = mutableListOf<String>()
+        var label = "initial"
+        var viewState: UiState = UiState.Ready(1)
+        val frameClock = BroadcastFrameClock()
+        var frameTimeNanos = 0L
+
+        suspend fun pumpFrame() {
+            testScheduler.runCurrent()
+            frameTimeNanos += 16_000_000L
+            frameClock.sendFrame(frameTimeNanos)
+            testScheduler.runCurrent()
+        }
+
+        withContext(frameClock) {
+            withRunningRecomposer { recomposer ->
+                val composition = Composition(NoOpApplier(), recomposer)
+                try {
+                    composition.setContent {
+                        ViewStore<UiState, UiAction, UiEvent>(
+                            state = viewState,
+                            eventFlow = events,
+                        ).handle<UiEvent.ValueChanged> { event ->
+                            handled += "${(state as UiState.Ready).value}:$label:${event.value}"
+                        }
+                    }
+                    repeat(2) { pumpFrame() }
+
+                    label = "updated"
+                    viewState = UiState.Ready(2)
+                    composition.setContent {
+                        ViewStore<UiState, UiAction, UiEvent>(
+                            state = viewState,
+                            eventFlow = events,
+                        ).handle<UiEvent.ValueChanged> { event ->
+                            handled += "${(state as UiState.Ready).value}:$label:${event.value}"
+                        }
+                    }
+                    repeat(2) { pumpFrame() }
+
+                    assertTrue(events.tryEmit(UiEvent.ValueChanged(42)))
+                    repeat(2) { pumpFrame() }
+                } finally {
+                    composition.dispose()
+                    pumpFrame()
+                }
+            }
+        }
+
+        assertEquals(listOf("2:updated:42"), handled)
+    }
+
+    @Test
     fun rememberViewStore_providesCurrentStateAndDispatchesAction() = runTest(testDispatcher) {
         val store = TestStore(UiState.Ready(1))
         lateinit var viewStore: ViewStore<UiState, UiAction, UiEvent>


### PR DESCRIPTION
## Summary
- update `ViewStore.handle` to read the latest receiver and callback via `rememberUpdatedState`
- add a JVM test covering recomposition before event delivery

## Why
- avoid invoking stale event handlers after recomposition when the event flow instance does not change

## Testing
- `JAVA_HOME=/Users/h_kusu/Library/Java/JavaVirtualMachines/AndroidStudio/Contents/Home ./gradlew :koma-compose:jvmTest`