### PR TITLE
Make DefaultLogger.isDisabled volatile for cross-thread visibility

### DIFF
--- a/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/DefaultLogger.kt
+++ b/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/DefaultLogger.kt
@@ -1,11 +1,13 @@
 package io.github.komakt.koma.logging
 
+import kotlin.concurrent.Volatile
 import co.touchlab.kermit.Logger.Companion as Kermit
 
 /**
  * Default [Logger] implementation backed by Kermit.
  */
 object DefaultLogger : Logger {
+    @Volatile
     private var isDisabled = false
 
     /**


### PR DESCRIPTION
## Summary
- Add `@Volatile` to `DefaultLogger.isDisabled` so the `disable()` write is published promptly to threads emitting logs from elsewhere.
- Import `kotlin.concurrent.Volatile` explicitly so the annotation resolves on every KMP target (in commonMain, `kotlin.jvm.Volatile` is JVM-only).

## Why
`DefaultLogger.disable()` is the intended one-way kill switch for production builds, but `isDisabled` was a plain `var` on an `object`. Under the JVM memory model, the write from the startup thread is not guaranteed to be visible to other threads immediately, so logs could keep flowing for a (likely short) window after `disable()` returns. `@Volatile` closes that gap while keeping the existing intentional design of no `enable()` counterpart.

## Test plan
- [x] `./gradlew :koma-logging:compileKotlinJvm`
- [x] `./gradlew :koma-logging:compileKotlinJs` (verifies the commonMain import resolves on a non-JVM target)
- [x] `./gradlew :koma-logging:jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)