### PR TITLE
Fix actionLaunchJobs data race by removing unsynchronized cleanup

### DIFF
--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
@@ -477,9 +477,8 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             is LaunchControl.CancelPrevious -> {
                 val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
                 cancelTrackedActionLaunch(stateRuntime, trackedKey)
-                stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
+                stateRuntime.actionLaunchJobs[trackedKey] = launchInStateRuntime(
                     stateRuntime = stateRuntime,
-                    trackedKey = trackedKey,
                     dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
@@ -489,36 +488,12 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
             is LaunchControl.DropIfRunning -> {
                 val trackedKey = resolveTrackedActionLaunchKey(action = action, control = control)
                 if (stateRuntime.actionLaunchJobs[trackedKey]?.isActive == true) return
-                stateRuntime.actionLaunchJobs[trackedKey] = launchTrackedActionInStateRuntime(
-                    stateRuntime = stateRuntime,
-                    trackedKey = trackedKey,
-                    dispatcher = dispatcher,
-                    buildLaunchScope = buildLaunchScope,
-                    block = block,
-                )
-            }
-        }
-    }
-
-    private fun <LS> launchTrackedActionInStateRuntime(
-        stateRuntime: StateRuntime,
-        trackedKey: Any,
-        dispatcher: CoroutineDispatcher?,
-        buildLaunchScope: () -> LS,
-        block: suspend LS.() -> Unit,
-    ): Job {
-        return stateRuntime.scope.launch(dispatcher ?: EmptyCoroutineContext) {
-            try {
-                executeLaunchInStateRuntime(
+                stateRuntime.actionLaunchJobs[trackedKey] = launchInStateRuntime(
                     stateRuntime = stateRuntime,
                     dispatcher = dispatcher,
                     buildLaunchScope = buildLaunchScope,
                     block = block,
                 )
-            } finally {
-                if (stateRuntime.actionLaunchJobs[trackedKey] === coroutineContext[Job]) {
-                    stateRuntime.actionLaunchJobs.remove(trackedKey)
-                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- `actionLaunchJobs` (a plain `mutableMapOf<Any, Job>` on `StateRuntime`) was modified from the launched coroutine's `finally` block without holding `mutex`, racing with writes performed under the mutex by `launchActionInStateRuntime`. On a multi-thread dispatcher this can corrupt the HashMap.
- The finally cleanup is removed entirely. No call site iterates the map: `DropIfRunning` checks `Job.isActive`, `CancelPrevious` overwrites, and `cancelLaunch` removes under the mutex.
- `launchTrackedActionInStateRuntime` became identical to `launchInStateRuntime` after the cleanup was removed, so it is dropped and the two call sites switch to `launchInStateRuntime`. The unused `trackedKey` parameter is removed along with it.

## Trade-off

Completed-Job references stay in `actionLaunchJobs` until the slot is overwritten (next dispatch on the same `trackedKey`) or the `StateRuntime` is removed on state exit. For the standard `trackedKey = action::class` pattern the map size stays bounded by the action class universe, so this is not a practical leak. The pathological case of dynamically-generated lane keys (e.g. `lane = "request-$id"`) would accumulate stale entries until the state changes; no existing test or usage exercises this pattern.

The alternative considered was wrapping the finally cleanup in `withContext(NonCancellable) { mutex.withLock { ... } }`. It preserves the prior eager-cleanup behavior but introduces additional invariants (non-cancellable context, captured `thisJob` identity check, no `cancelAndJoin` under mutex anywhere upstream) that have to stay true across future refactors. Given no caller depends on eager cleanup today, removing the path entirely is the safer change.

## Test plan

- [x] `./gradlew :koma-core:jvmTest :koma-test:jvmTest :koma-message:jvmTest :koma-logging:jvmTest` locally (all green; `StoreCancelLaunchTest`, `StoreLaunchControlTest`, `StorePendingActionCancellationTest`, `StoreConcurrentTest` confirmed)
- [ ] CI: `iosSimulatorArm64Test`, `jsBrowserTest`, `wasmJsBrowserTest`, `testAndroidHostTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)