### PR TITLE
Rename built-in exception handlers

### DIFF
--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
@@ -19,9 +19,16 @@ interface ExceptionHandler {
         /**
          * Ignores all handled exceptions.
          */
-        val Noop: ExceptionHandler = object : ExceptionHandler {
+        val Ignore: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {}
         }
+
+        /**
+         * Deprecated alias for [Ignore].
+         */
+        @Deprecated(message = "Use Ignore", replaceWith = ReplaceWith("ExceptionHandler.Ignore"))
+        val Noop: ExceptionHandler
+            get() = Ignore
 
         /**
          * Prints the exception message and stack trace for debugging.
@@ -36,11 +43,18 @@ interface ExceptionHandler {
         /**
          * Rethrows handled exceptions instead of swallowing them.
          */
-        val Unhandled: ExceptionHandler = object : ExceptionHandler {
+        val Rethrow: ExceptionHandler = object : ExceptionHandler {
             override fun handle(error: Throwable) {
                 throw error
             }
         }
+
+        /**
+         * Deprecated alias for [Rethrow].
+         */
+        @Deprecated(message = "Use Rethrow", replaceWith = ReplaceWith("ExceptionHandler.Rethrow"))
+        val Unhandled: ExceptionHandler
+            get() = Rethrow
     }
 }
 

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreBuilder.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreBuilder.kt
@@ -17,7 +17,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     private var storeInitialState: S? = null
     private var storeCoroutineContext: CoroutineContext = Dispatchers.Default
     private var storeStateSaver: StateSaver<S> = StateSaver.Noop()
-    private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Unhandled
+    private var storeExceptionHandler: ExceptionHandler = ExceptionHandler.Rethrow
     private var storeAutoStartPolicy: AutoStartPolicy = AutoStartPolicy.OnDispatchOrStateCollection
     private var storePendingActionPolicy: PendingActionPolicy = PendingActionPolicy.ClearOnStateExit
     private var storePluginExecutionPolicy: PluginExecutionPolicy = PluginExecutionPolicy.Concurrent

--- a/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreActionCoroutineScopeTest.kt
+++ b/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreActionCoroutineScopeTest.kt
@@ -40,7 +40,7 @@ class StoreActionCoroutineScopeTest {
     private fun createTestStore(
         onLongRunningStart: (() -> Unit)? = null,
         onLongRunningCancelled: (() -> Unit)? = null,
-        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Ignore,
     ): Store<AppState, AppAction, Nothing> {
         return Store(AppState.Active()) {
             coroutineContext(Dispatchers.Unconfined)

--- a/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StorePluginExceptionTest.kt
+++ b/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StorePluginExceptionTest.kt
@@ -27,7 +27,7 @@ class StorePluginExceptionTest {
 
     private fun createStore(
         plugin: Plugin<AppState, AppAction, Nothing>,
-        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Ignore,
     ): Store<AppState, AppAction, Nothing> {
         return Store(AppState.Ready()) {
             coroutineContext(Dispatchers.Unconfined)

--- a/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreSaverTest.kt
+++ b/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreSaverTest.kt
@@ -21,7 +21,7 @@ class StoreSaverTest {
     private fun createTestStore(
         initialState: AppState,
         stateSaver: StateSaver<AppState>,
-        exceptionHandler: ExceptionHandler = ExceptionHandler.Noop,
+        exceptionHandler: ExceptionHandler = ExceptionHandler.Ignore,
         errorStateOnException: AppState? = null,
     ): Store<AppState, AppAction, Nothing> {
         return Store(initialState) {


### PR DESCRIPTION
## Summary
- rename built-in exception handlers from Noop/Unhandled to Ignore/Rethrow
- keep the old names as deprecated aliases with ReplaceWith guidance
- update the default handler reference and JVM test helpers to use the new names

## Why
- make the built-in handler names describe their behavior directly
- keep the API migration source-compatible for existing callers

## Verification
- ./gradlew :koma-core:compileCommonMainKotlinMetadata :koma-core:compileTestKotlinJvm --rerun-tasks