### PR TITLE
Rename ViewStore render and handle APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,37 +757,37 @@ Text(
 )
 ```
 
-If there are multiple *States*, use the `.render()` method for the target *State*.
+If there are multiple *States*, use the `.renderState()` method for the target *State*.
 
 ```kt
-viewStore.render<CounterState.Main> {
+viewStore.renderState<CounterState.Main> {
     Text(
         text = state.count.toString(),
     )
 }
 ```
 
-When drawing the UI, if it does not match the target *State*, the `.render()` will not be executed.
+When drawing the UI, if it does not match the target *State*, the `.renderState()` will not be executed.
 Therefore, you can define components for each *State* side by side.
 
 ```kt
-viewStore.render<CounterState.Loading> {
+viewStore.renderState<CounterState.Loading> {
     Text(
         text = "loading..",
     )
 }
 
-viewStore.render<CounterState.Main> {
+viewStore.renderState<CounterState.Main> {
     Text(
         text = state.count.toString(),
     )
 }
 ```
 
-If you use lower components in the `render()` block, pass its instance.
+If you use lower components in the `renderState()` block, pass its instance.
 
 ```kt
-viewStore.render<CounterState.Main> {
+viewStore.renderState<CounterState.Main> {
     YourComposable(
         viewStore = this, // ViewStore instance for CounterState.Main
     )
@@ -822,10 +822,10 @@ Button(
 
 ### Handling Events
 
-Use ViewStore's `.handle()` with the target *Event*.
+Use ViewStore's `.collectEvent()` with the target *Event*.
 
 ```kt
-viewStore.handle<CounterEvent.ShowToast> { event ->
+viewStore.collectEvent<CounterEvent.ShowToast> { event ->
     // do something..
 }
 ```
@@ -833,7 +833,7 @@ viewStore.handle<CounterEvent.ShowToast> { event ->
 In the above example, you can also subscribe to the parent *Event* type.
 
 ```kt
-viewStore.handle<CounterEvent> { event ->
+viewStore.collectEvent<CounterEvent> { event ->
     when (event) {
         is CounterEvent.ShowToast -> // do something..
         is CounterEvent.GoBack -> // do something..

--- a/README.md
+++ b/README.md
@@ -757,37 +757,37 @@ Text(
 )
 ```
 
-If there are multiple *States*, use the `.renderState()` method for the target *State*.
+If there are multiple *States*, use the `.stateContent()` method for the target *State*.
 
 ```kt
-viewStore.renderState<CounterState.Main> {
+viewStore.stateContent<CounterState.Main> {
     Text(
         text = state.count.toString(),
     )
 }
 ```
 
-When drawing the UI, if it does not match the target *State*, the `.renderState()` will not be executed.
+When drawing the UI, if it does not match the target *State*, the `.stateContent()` will not be executed.
 Therefore, you can define components for each *State* side by side.
 
 ```kt
-viewStore.renderState<CounterState.Loading> {
+viewStore.stateContent<CounterState.Loading> {
     Text(
         text = "loading..",
     )
 }
 
-viewStore.renderState<CounterState.Main> {
+viewStore.stateContent<CounterState.Main> {
     Text(
         text = state.count.toString(),
     )
 }
 ```
 
-If you use lower components in the `renderState()` block, pass its instance.
+If you use lower components in the `stateContent()` block, pass its instance.
 
 ```kt
-viewStore.renderState<CounterState.Main> {
+viewStore.stateContent<CounterState.Main> {
     YourComposable(
         viewStore = this, // ViewStore instance for CounterState.Main
     )
@@ -822,10 +822,10 @@ Button(
 
 ### Handling Events
 
-Use ViewStore's `.collectEvent()` with the target *Event*.
+Use ViewStore's `.eventEffect()` with the target *Event*.
 
 ```kt
-viewStore.collectEvent<CounterEvent.ShowToast> { event ->
+viewStore.eventEffect<CounterEvent.ShowToast> { event ->
     // do something..
 }
 ```
@@ -833,7 +833,7 @@ viewStore.collectEvent<CounterEvent.ShowToast> { event ->
 In the above example, you can also subscribe to the parent *Event* type.
 
 ```kt
-viewStore.collectEvent<CounterEvent> { event ->
+viewStore.eventEffect<CounterEvent> { event ->
     when (event) {
         is CounterEvent.ShowToast -> // do something..
         is CounterEvent.GoBack -> // do something..

--- a/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
+++ b/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
@@ -1,26 +1,26 @@
 # `ViewStore.render` / `handle` の PascalCase 置き換えは採用しない
 
-- 更新日: 2026-04-30
+- 更新日: 2026-05-25
 
 ## 背景
 
-`ViewStore.renderState` / `ViewStore.collectEvent` は `@Composable` であり、Compose の naming guideline にそのまま寄せるなら、`Unit` を返す public composable として PascalCase の名前にしたくなる。
+`ViewStore.render` / `ViewStore.handle` は `@Composable` であり、Compose の naming guideline にそのまま寄せるなら、`Unit` を返す public composable として PascalCase の名前にしたくなる。
 
 このため、次の 2 方向を検討した。
 
 - トップレベル関数として `StateContent(viewStore) {}` / `EventHandler(viewStore) {}`
 - `ViewStore` のメンバ関数として `viewStore.StateContent {}` / `viewStore.EventHandler {}`
 
-ただし、どちらも現在の `viewStore.renderState {}` / `viewStore.collectEvent {}` が持つ DSL としての自然さを崩す懸念があった。
+ただし、どちらも現在の `viewStore.render {}` / `viewStore.handle {}` が持つ DSL としての自然さを崩す懸念があった。
 
 ## 決定
 
-`ViewStore.renderState` / `ViewStore.collectEvent` を PascalCase の別 API に置き換える案は採用しない。
+`ViewStore.render` / `ViewStore.handle` を PascalCase の別 API に置き換える案は採用しない。
 
 現時点では、既存の lowerCamelCase API を維持する。
 
-- `viewStore.renderState<...> { ... }`
-- `viewStore.collectEvent<...> { ... }`
+- `viewStore.render<...> { ... }`
+- `viewStore.handle<...> { ... }`
 
 ## 補足
 
@@ -29,3 +29,8 @@
 - そのため今回は「Compose guideline への整合」より、「`ViewStore` DSL としての自然さ」を優先する。
 - 既存 API には `@Suppress("ComposableNaming")` が必要だが、このコストは上記の不自然さを受け入れるより小さいと判断する。
 - 将来、トップレベルでもメンバでもない、より自然な API 形が見つかった場合はあらためて検討してよい。
+
+## 2026-05-25 追記
+
+その後、API 名は `render` / `handle` から `stateContent` / `eventEffect` へリネームされた。
+この rename により、API の意味は Compose 文脈により沿うようになったが、member composable を PascalCase にするかという論点自体は変わっていない。

--- a/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
+++ b/doc/internal/adr/2026-04-30-viewstore-compose-naming.md
@@ -4,23 +4,23 @@
 
 ## 背景
 
-`ViewStore.render` / `ViewStore.handle` は `@Composable` であり、Compose の naming guideline にそのまま寄せるなら、`Unit` を返す public composable として PascalCase の名前にしたくなる。
+`ViewStore.renderState` / `ViewStore.collectEvent` は `@Composable` であり、Compose の naming guideline にそのまま寄せるなら、`Unit` を返す public composable として PascalCase の名前にしたくなる。
 
 このため、次の 2 方向を検討した。
 
 - トップレベル関数として `StateContent(viewStore) {}` / `EventHandler(viewStore) {}`
 - `ViewStore` のメンバ関数として `viewStore.StateContent {}` / `viewStore.EventHandler {}`
 
-ただし、どちらも現在の `viewStore.render {}` / `viewStore.handle {}` が持つ DSL としての自然さを崩す懸念があった。
+ただし、どちらも現在の `viewStore.renderState {}` / `viewStore.collectEvent {}` が持つ DSL としての自然さを崩す懸念があった。
 
 ## 決定
 
-`ViewStore.render` / `ViewStore.handle` を PascalCase の別 API に置き換える案は採用しない。
+`ViewStore.renderState` / `ViewStore.collectEvent` を PascalCase の別 API に置き換える案は採用しない。
 
 現時点では、既存の lowerCamelCase API を維持する。
 
-- `viewStore.render<...> { ... }`
-- `viewStore.handle<...> { ... }`
+- `viewStore.renderState<...> { ... }`
+- `viewStore.collectEvent<...> { ... }`
 
 ## 補足
 

--- a/doc/internal/notes/2026-04-23-store-start-policy.md
+++ b/doc/internal/notes/2026-04-23-store-start-policy.md
@@ -52,7 +52,7 @@ fun startPolicy(policy: StoreStartPolicy)
 - 未採用候補として `EAGER` も考えられる。これは「`dispatch()` や `state` の collect を待たず、Store 作成直後に start する」という意味になる。v1 では見送るのがよい。`attachObserver()` が start 前のみ許可という現行前提と衝突しやすい。
 - `ON_FIRST_DISPATCH` では、`state` を collect しても start しない。その場合でも `StateFlow` としては current snapshot を読めるので、UI が「現在値の監視」と「副作用の開始」を分離しやすくなる。
 - start 直後に `enter { event(...) }` のような one-shot event を出したい場合、現状の default では `state` の collect が先に start trigger になり、あとから `event` を購読した側が初回 event を見逃しうる。
-- この問題は Compose の `rememberViewStore()` でも起こりうる。`rememberViewStore()` は内部で `store.state.collectAsState()` を行う一方、event の collect は `ViewStore.collectEvent()` 側の `LaunchedEffect` で始まるため、同じ画面内で両方を書いていても event collector が start 前に間に合う保証はない。
+- この問題は Compose の `rememberViewStore()` でも起こりうる。`rememberViewStore()` は内部で `store.state.collectAsState()` を行う一方、event の collect は `ViewStore.eventEffect()` 側の `LaunchedEffect` で始まるため、同じ画面内で両方を書いていても event collector が start 前に間に合う保証はない。
 - この問題に対しては start policy が有効な回避策になりうる。`ON_FIRST_DISPATCH` なら `state` / `event` の購読を張ったあとに明示的な最初の `dispatch()` で start でき、`MANUAL` なら購読を張ったあとに `start()` を呼ぶ順序をさらに明示しやすい。
 - ただし start policy が解決するのは「購読前に start しない」ことまでであり、`Store.event` 自体の replay semantics は変えない。start 後に購読した側へ過去 event を再配送するわけではない。
 - `MANUAL` で start 前に `dispatch()` された場合は、暗黙 start や silently ignore ではなく、例外で失敗させる方がバグを早く見つけやすい。

--- a/doc/internal/notes/2026-04-23-store-start-policy.md
+++ b/doc/internal/notes/2026-04-23-store-start-policy.md
@@ -52,7 +52,7 @@ fun startPolicy(policy: StoreStartPolicy)
 - 未採用候補として `EAGER` も考えられる。これは「`dispatch()` や `state` の collect を待たず、Store 作成直後に start する」という意味になる。v1 では見送るのがよい。`attachObserver()` が start 前のみ許可という現行前提と衝突しやすい。
 - `ON_FIRST_DISPATCH` では、`state` を collect しても start しない。その場合でも `StateFlow` としては current snapshot を読めるので、UI が「現在値の監視」と「副作用の開始」を分離しやすくなる。
 - start 直後に `enter { event(...) }` のような one-shot event を出したい場合、現状の default では `state` の collect が先に start trigger になり、あとから `event` を購読した側が初回 event を見逃しうる。
-- この問題は Compose の `rememberViewStore()` でも起こりうる。`rememberViewStore()` は内部で `store.state.collectAsState()` を行う一方、event の collect は `ViewStore.handle()` 側の `LaunchedEffect` で始まるため、同じ画面内で両方を書いていても event collector が start 前に間に合う保証はない。
+- この問題は Compose の `rememberViewStore()` でも起こりうる。`rememberViewStore()` は内部で `store.state.collectAsState()` を行う一方、event の collect は `ViewStore.collectEvent()` 側の `LaunchedEffect` で始まるため、同じ画面内で両方を書いていても event collector が start 前に間に合う保証はない。
 - この問題に対しては start policy が有効な回避策になりうる。`ON_FIRST_DISPATCH` なら `state` / `event` の購読を張ったあとに明示的な最初の `dispatch()` で start でき、`MANUAL` なら購読を張ったあとに `start()` を呼ぶ順序をさらに明示しやすい。
 - ただし start policy が解決するのは「購読前に start しない」ことまでであり、`Store.event` 自体の replay semantics は変えない。start 後に購読した側へ過去 event を再配送するわけではない。
 - `MANUAL` で start 前に `dispatch()` された場合は、暗黙 start や silently ignore ではなく、例外で失敗させる方がバグを早く見つけやすい。

--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -59,11 +59,11 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
      *
      * Inside [block], this [ViewStore] is narrowed to [S2].
      *
-     * @param block Composable function to render the narrowed state
+     * @param block Composable function to render content for the narrowed state
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified S2 : S> renderState(block: @Composable ViewStore<S2, A, E>.() -> Unit) {
+    inline fun <reified S2 : S> stateContent(block: @Composable ViewStore<S2, A, E>.() -> Unit) {
         if (state is S2) {
             @Suppress("UNCHECKED_CAST")
             block(this as ViewStore<S2, A, E>)
@@ -71,13 +71,13 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
     }
 
     @Deprecated(
-        message = "Use renderState instead.",
-        replaceWith = ReplaceWith("renderState<S2>(block)"),
+        message = "Use stateContent instead.",
+        replaceWith = ReplaceWith("stateContent<S2>(block)"),
         level = DeprecationLevel.WARNING,
     )
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified S2 : S> render(block: @Composable ViewStore<S2, A, E>.() -> Unit) = renderState<S2>(block)
+    inline fun <reified S2 : S> render(block: @Composable ViewStore<S2, A, E>.() -> Unit) = stateContent<S2>(block)
 
     /**
      * Collects only events of type [E2] while this composable is in the composition.
@@ -89,7 +89,7 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified E2 : E> collectEvent(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
+    inline fun <reified E2 : E> eventEffect(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
         val currentViewStore = rememberUpdatedState(this)
         val currentBlock = rememberUpdatedState(block)
         LaunchedEffect(eventFlow) {
@@ -100,20 +100,20 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
     }
 
     @Deprecated(
-        message = "Use collectEvent instead.",
-        replaceWith = ReplaceWith("collectEvent<E2>(block)"),
+        message = "Use eventEffect instead.",
+        replaceWith = ReplaceWith("eventEffect<E2>(block)"),
         level = DeprecationLevel.WARNING,
     )
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified E2 : E> handle(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) = collectEvent<E2>(block)
+    inline fun <reified E2 : E> handle(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) = eventEffect<E2>(block)
 }
 
 /**
  * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
  * Collecting [Store.state] starts the Store immediately.
- * Because [ViewStore.collectEvent] starts collecting later from a [LaunchedEffect], startup events
+ * Because [ViewStore.eventEffect] starts collecting later from a [LaunchedEffect], startup events
  * such as events emitted from an initial `enter {}` handler may be emitted before handlers in the
  * same composition begin observing them.
  *

--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -63,12 +63,21 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified S2 : S> render(block: @Composable ViewStore<S2, A, E>.() -> Unit) {
+    inline fun <reified S2 : S> renderState(block: @Composable ViewStore<S2, A, E>.() -> Unit) {
         if (state is S2) {
             @Suppress("UNCHECKED_CAST")
             block(this as ViewStore<S2, A, E>)
         }
     }
+
+    @Deprecated(
+        message = "Use renderState instead.",
+        replaceWith = ReplaceWith("renderState<S2>(block)"),
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("ComposableNaming")
+    @Composable
+    inline fun <reified S2 : S> render(block: @Composable ViewStore<S2, A, E>.() -> Unit) = renderState<S2>(block)
 
     /**
      * Collects only events of type [E2] while this composable is in the composition.
@@ -80,7 +89,7 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
      */
     @Suppress("ComposableNaming")
     @Composable
-    inline fun <reified E2 : E> handle(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
+    inline fun <reified E2 : E> collectEvent(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) {
         val currentViewStore = rememberUpdatedState(this)
         val currentBlock = rememberUpdatedState(block)
         LaunchedEffect(eventFlow) {
@@ -89,15 +98,24 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
             }
         }
     }
+
+    @Deprecated(
+        message = "Use collectEvent instead.",
+        replaceWith = ReplaceWith("collectEvent<E2>(block)"),
+        level = DeprecationLevel.WARNING,
+    )
+    @Suppress("ComposableNaming")
+    @Composable
+    inline fun <reified E2 : E> handle(noinline block: ViewStore<S, A, E>.(event: E2) -> Unit) = collectEvent<E2>(block)
 }
 
 /**
  * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
  * Collecting [Store.state] starts the Store immediately.
- * Because [ViewStore.handle] starts collecting later from a [LaunchedEffect], startup events such
- * as events emitted from an initial `enter {}` handler may be emitted before handlers in the same
- * composition begin observing them.
+ * Because [ViewStore.collectEvent] starts collecting later from a [LaunchedEffect], startup events
+ * such as events emitted from an initial `enter {}` handler may be emitted before handlers in the
+ * same composition begin observing them.
  *
  * The [store] lambda is used only when a new remembered Store must be created for [key].
  * For a given remembered Store instance, this function returns the same [ViewStore] instance across

--- a/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
+++ b/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
@@ -32,18 +32,18 @@ class ViewStoreJvmTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun render_callsBlockOnlyForMatchingState() = runTest(testDispatcher) {
+    fun renderState_callsBlockOnlyForMatchingState() = runTest(testDispatcher) {
         val renderedValues = mutableListOf<Int>()
 
         withComposition(
             content = {
                 ViewStore<UiState, Nothing, Nothing>(state = UiState.Ready(10))
-                    .render<UiState.Ready> {
+                    .renderState<UiState.Ready> {
                         renderedValues += state.value
                     }
 
                 ViewStore<UiState, Nothing, Nothing>(state = UiState.Loading)
-                    .render<UiState.Ready> {
+                    .renderState<UiState.Ready> {
                         renderedValues += state.value
                     }
             },
@@ -53,7 +53,7 @@ class ViewStoreJvmTest {
     }
 
     @Test
-    fun handle_collectsOnlySpecifiedEventType() = runTest(testDispatcher) {
+    fun collectEvent_collectsOnlySpecifiedEventType() = runTest(testDispatcher) {
         val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
         val handled = mutableListOf<UiEvent.ValueChanged>()
 
@@ -62,7 +62,7 @@ class ViewStoreJvmTest {
                 ViewStore<UiState, UiAction, UiEvent>(
                     state = UiState.Ready(0),
                     eventFlow = events,
-                ).handle<UiEvent.ValueChanged> { event ->
+                ).collectEvent<UiEvent.ValueChanged> { event ->
                     handled += event
                 }
             },
@@ -76,7 +76,7 @@ class ViewStoreJvmTest {
     }
 
     @Test
-    fun handle_usesLatestViewStoreAndLambdaAfterRecomposition() = runTest(testDispatcher) {
+    fun collectEvent_usesLatestViewStoreAndLambdaAfterRecomposition() = runTest(testDispatcher) {
         val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
         val handled = mutableListOf<String>()
         var label = "initial"
@@ -99,7 +99,7 @@ class ViewStoreJvmTest {
                         ViewStore<UiState, UiAction, UiEvent>(
                             state = viewState,
                             eventFlow = events,
-                        ).handle<UiEvent.ValueChanged> { event ->
+                        ).collectEvent<UiEvent.ValueChanged> { event ->
                             handled += "${(state as UiState.Ready).value}:$label:${event.value}"
                         }
                     }
@@ -111,7 +111,7 @@ class ViewStoreJvmTest {
                         ViewStore<UiState, UiAction, UiEvent>(
                             state = viewState,
                             eventFlow = events,
-                        ).handle<UiEvent.ValueChanged> { event ->
+                        ).collectEvent<UiEvent.ValueChanged> { event ->
                             handled += "${(state as UiState.Ready).value}:$label:${event.value}"
                         }
                     }
@@ -127,6 +127,46 @@ class ViewStoreJvmTest {
         }
 
         assertEquals(listOf("2:updated:42"), handled)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun render_delegatesToRenderState() = runTest(testDispatcher) {
+        val renderedValues = mutableListOf<Int>()
+
+        withComposition(
+            content = {
+                ViewStore<UiState, Nothing, Nothing>(state = UiState.Ready(7))
+                    .render<UiState.Ready> {
+                        renderedValues += state.value
+                    }
+            },
+        )
+
+        assertEquals(listOf(7), renderedValues)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun handle_delegatesToCollectEvent() = runTest(testDispatcher) {
+        val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
+        val handled = mutableListOf<UiEvent.ValueChanged>()
+
+        withComposition(
+            content = {
+                ViewStore<UiState, UiAction, UiEvent>(
+                    state = UiState.Ready(0),
+                    eventFlow = events,
+                ).handle<UiEvent.ValueChanged> { event ->
+                    handled += event
+                }
+            },
+            afterSetContent = {
+                assertTrue(events.tryEmit(UiEvent.ValueChanged(99)))
+            },
+        )
+
+        assertEquals(listOf(UiEvent.ValueChanged(99)), handled)
     }
 
     @Test

--- a/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
+++ b/koma-compose/src/jvmTest/kotlin/io/github/komakt/koma/compose/ViewStoreJvmTest.kt
@@ -32,18 +32,18 @@ class ViewStoreJvmTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun renderState_callsBlockOnlyForMatchingState() = runTest(testDispatcher) {
+    fun stateContent_callsBlockOnlyForMatchingState() = runTest(testDispatcher) {
         val renderedValues = mutableListOf<Int>()
 
         withComposition(
             content = {
                 ViewStore<UiState, Nothing, Nothing>(state = UiState.Ready(10))
-                    .renderState<UiState.Ready> {
+                    .stateContent<UiState.Ready> {
                         renderedValues += state.value
                     }
 
                 ViewStore<UiState, Nothing, Nothing>(state = UiState.Loading)
-                    .renderState<UiState.Ready> {
+                    .stateContent<UiState.Ready> {
                         renderedValues += state.value
                     }
             },
@@ -53,7 +53,7 @@ class ViewStoreJvmTest {
     }
 
     @Test
-    fun collectEvent_collectsOnlySpecifiedEventType() = runTest(testDispatcher) {
+    fun eventEffect_collectsOnlySpecifiedEventType() = runTest(testDispatcher) {
         val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
         val handled = mutableListOf<UiEvent.ValueChanged>()
 
@@ -62,7 +62,7 @@ class ViewStoreJvmTest {
                 ViewStore<UiState, UiAction, UiEvent>(
                     state = UiState.Ready(0),
                     eventFlow = events,
-                ).collectEvent<UiEvent.ValueChanged> { event ->
+                ).eventEffect<UiEvent.ValueChanged> { event ->
                     handled += event
                 }
             },
@@ -76,7 +76,7 @@ class ViewStoreJvmTest {
     }
 
     @Test
-    fun collectEvent_usesLatestViewStoreAndLambdaAfterRecomposition() = runTest(testDispatcher) {
+    fun eventEffect_usesLatestViewStoreAndLambdaAfterRecomposition() = runTest(testDispatcher) {
         val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
         val handled = mutableListOf<String>()
         var label = "initial"
@@ -99,7 +99,7 @@ class ViewStoreJvmTest {
                         ViewStore<UiState, UiAction, UiEvent>(
                             state = viewState,
                             eventFlow = events,
-                        ).collectEvent<UiEvent.ValueChanged> { event ->
+                        ).eventEffect<UiEvent.ValueChanged> { event ->
                             handled += "${(state as UiState.Ready).value}:$label:${event.value}"
                         }
                     }
@@ -111,7 +111,7 @@ class ViewStoreJvmTest {
                         ViewStore<UiState, UiAction, UiEvent>(
                             state = viewState,
                             eventFlow = events,
-                        ).collectEvent<UiEvent.ValueChanged> { event ->
+                        ).eventEffect<UiEvent.ValueChanged> { event ->
                             handled += "${(state as UiState.Ready).value}:$label:${event.value}"
                         }
                     }
@@ -131,7 +131,7 @@ class ViewStoreJvmTest {
 
     @Suppress("DEPRECATION")
     @Test
-    fun render_delegatesToRenderState() = runTest(testDispatcher) {
+    fun render_delegatesToStateContent() = runTest(testDispatcher) {
         val renderedValues = mutableListOf<Int>()
 
         withComposition(
@@ -148,7 +148,7 @@ class ViewStoreJvmTest {
 
     @Suppress("DEPRECATION")
     @Test
-    fun handle_delegatesToCollectEvent() = runTest(testDispatcher) {
+    fun handle_delegatesToEventEffect() = runTest(testDispatcher) {
         val events = MutableSharedFlow<UiEvent>(extraBufferCapacity = 4)
         val handled = mutableListOf<UiEvent.ValueChanged>()
 
@@ -162,11 +162,11 @@ class ViewStoreJvmTest {
                 }
             },
             afterSetContent = {
-                assertTrue(events.tryEmit(UiEvent.ValueChanged(99)))
+                assertTrue(events.tryEmit(UiEvent.ValueChanged(100)))
             },
         )
 
-        assertEquals(listOf(UiEvent.ValueChanged(99)), handled)
+        assertEquals(listOf(UiEvent.ValueChanged(100)), handled)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rename the `ViewStore` composable helpers from `render` and `handle` to `stateContent` and `eventEffect`
- keep `render` and `handle` as deprecated forwarding APIs to preserve source compatibility during migration
- update the README, internal notes, and JVM tests to use the new names

## Why
- make the state rendering and event collection roles more explicit in Compose usage
- avoid the ambiguity of shorter names around the existing `viewStore.state` property

## Impact
- existing call sites continue to compile through the deprecated wrappers
- new documentation and tests point users to the replacement APIs

## Verification
- `./gradlew :koma-compose:jvmTest`