### PR TITLE
Rename LaunchControl.Concurrent to Untracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,8 +520,8 @@ val store = Store(MyState.Active()) {
 `LaunchControl.CancelPrevious(lane)` cancels the previous tracked launch in the same lane before starting the next one.
 `LaunchControl.DropIfRunning(lane)` ignores a new launch while tracked work in the same lane is still active.
 When the lane is omitted, `LaunchControl.CancelPrevious()` and `LaunchControl.DropIfRunning()` use the same internal default lane for that `action {}` block.
-`LaunchControl.Concurrent` keeps the default behavior and runs launches independently.
-`cancelLaunch(lane)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.CancelPrevious(...)` and `LaunchControl.DropIfRunning(...)`. Use an explicit `LaunchLane()` when you need to share a lane across multiple launches or cancel it later. It does not cancel `LaunchControl.Concurrent` launches or `enter { launch { ... } }`.
+`LaunchControl.Untracked` keeps the default behavior and runs launches independently.
+`cancelLaunch(lane)` only affects coroutines started from `action { launch { ... } }` in the current active state's runtime that use tracked controls such as `LaunchControl.CancelPrevious(...)` and `LaunchControl.DropIfRunning(...)`. Use an explicit `LaunchLane()` when you need to share a lane across multiple launches or cancel it later. It does not cancel `LaunchControl.Untracked` launches or `enter { launch { ... } }`.
 
 ### Specifying coroutineContext
 

--- a/doc/internal/adr/2026-05-01-launch-control-case-naming.md
+++ b/doc/internal/adr/2026-05-01-launch-control-case-naming.md
@@ -15,7 +15,7 @@
 
 `LaunchControl` は、次の case を持つ API として公開する。
 
-- `LaunchControl.Concurrent` (デフォルト。通常は省略される。)
+- `LaunchControl.Untracked` (デフォルト。通常は省略される。)
 - `LaunchControl.CancelPrevious`
 - `LaunchControl.DropIfRunning`
 

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/LaunchControl.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/LaunchControl.kt
@@ -11,7 +11,7 @@ class LaunchLane
 /**
  * Controls how `action {}` launches coordinate with other tracked launches in the same lane.
  *
- * [Concurrent] launches are not tracked by lane.
+ * [Untracked] launches are not tracked by lane.
  * [CancelPrevious] and [DropIfRunning] create tracked lanes. When [LaunchLane] is omitted, the
  * launch uses a default lane derived from the current action type, so matching launches
  * coordinate across dispatches of that action type.
@@ -21,7 +21,7 @@ sealed interface LaunchControl {
     /**
      * Launch every invocation independently without lane tracking.
      */
-    data object Concurrent : LaunchControl
+    data object Untracked : LaunchControl
 
     /**
      * Cancel the previous tracked launch in the same lane before starting a new one.

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
@@ -457,7 +457,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
         block: suspend LS.() -> Unit,
     ) {
         when (control) {
-            LaunchControl.Concurrent -> {
+            LaunchControl.Untracked -> {
                 launchInStateRuntime(
                     stateRuntime = stateRuntime,
                     dispatcher = dispatcher,
@@ -492,7 +492,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     private fun resolveTrackedActionLaunchKey(action: A, control: LaunchControl): Any {
         return when (control) {
-            LaunchControl.Concurrent -> error("Concurrent launches do not have a tracked lane")
+            LaunchControl.Untracked -> error("Untracked launches do not have a tracked lane")
             is LaunchControl.CancelPrevious -> control.lane ?: action::class
             is LaunchControl.DropIfRunning -> control.lane ?: action::class
         }

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreScope.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreScope.kt
@@ -292,7 +292,7 @@ interface ActionScope<S : State, A : Action, E : Event, S2 : S> : StoreScope {
      * explicit [LaunchLane] or the default lane for the current action type.
      * @param block The suspending block of code to execute
      */
-    fun launch(dispatcher: CoroutineDispatcher? = null, control: LaunchControl = LaunchControl.Concurrent, block: suspend ActionLaunchScope<S, A, E, S2>.() -> Unit)
+    fun launch(dispatcher: CoroutineDispatcher? = null, control: LaunchControl = LaunchControl.Untracked, block: suspend ActionLaunchScope<S, A, E, S2>.() -> Unit)
 
     /**
      * Scope available within a state-scoped coroutine launched from `action {}`.

--- a/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreCancelLaunchTest.kt
+++ b/koma-core/src/commonTest/kotlin/io/github/komakt/koma/core/StoreCancelLaunchTest.kt
@@ -23,7 +23,7 @@ class StoreCancelLaunchTest {
         data class StartDropIfRunningShared(val marker: Int) : AppAction
         data class StartDropIfRunningOther(val marker: Int) : AppAction
         data class StartCancelPreviousShared(val marker: Int) : AppAction
-        data class StartConcurrentShared(val marker: Int) : AppAction
+        data class StartUntrackedShared(val marker: Int) : AppAction
         data object StartEnterLaunch : AppAction
         data object CancelShared : AppAction
         data object CancelMissing : AppAction
@@ -91,10 +91,10 @@ class StoreCancelLaunchTest {
                     }
                 }
 
-                action<AppAction.StartConcurrentShared> {
+                action<AppAction.StartUntrackedShared> {
                     launch(
                         dispatcher = testDispatcher,
-                        control = LaunchControl.Concurrent,
+                        control = LaunchControl.Untracked,
                     ) {
                         onStart?.invoke(action.marker)
                         try {
@@ -221,7 +221,7 @@ class StoreCancelLaunchTest {
     }
 
     @Test
-    fun cancelLaunch_doesNotCancelConcurrentLaunches() = runTest {
+    fun cancelLaunch_doesNotCancelUntrackedLaunches() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val cancelled = mutableListOf<Int>()
         val store = createStore(
@@ -229,7 +229,7 @@ class StoreCancelLaunchTest {
             onCancel = { cancelled += it },
         )
 
-        store.dispatch(AppAction.StartConcurrentShared(marker = 7))
+        store.dispatch(AppAction.StartUntrackedShared(marker = 7))
         runCurrent()
 
         store.dispatch(AppAction.CancelShared)


### PR DESCRIPTION
## Summary
- rename LaunchControl.Concurrent to LaunchControl.Untracked in the public API
- update runtime handling, tests, and documentation to use the new name

## Why
- make the default launch control name reflect that these launches are not tracked by lane

## Verification
- :koma-core:jvmTest