### PR TITLE
Make KomaStoreDsl public

### DIFF
--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Annotations.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/Annotations.kt
@@ -37,4 +37,4 @@ annotation class InternalKomaApi
 @DslMarker
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS)
-internal annotation class KomaStoreDsl
+annotation class KomaStoreDsl


### PR DESCRIPTION
## Summary
- make KomaStoreDsl public in koma-core
- allow downstream users to reuse the same DSL marker in custom Store DSL extensions

## Why
- users can build custom Store DSL scopes that share the same DSL boundary as built-in Koma scopes

## Verification
- Ran :koma-core:compileKotlinJvm