### PR TITLE
Remove Assert severity from logger

### DIFF
--- a/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/DefaultLogger.kt
+++ b/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/DefaultLogger.kt
@@ -21,7 +21,6 @@ object DefaultLogger : Logger {
             Logger.Severity.Info -> Kermit.i(tag, throwable, message)
             Logger.Severity.Warn -> Kermit.w(tag, throwable, message)
             Logger.Severity.Error -> Kermit.e(tag, throwable, message)
-            Logger.Severity.Assert -> Kermit.a(tag, throwable, message)
         }
     }
 

--- a/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/Logger.kt
+++ b/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/Logger.kt
@@ -37,8 +37,5 @@ fun interface Logger {
 
         /** Error information */
         Error,
-
-        /** Critical error information */
-        Assert,
     }
 }


### PR DESCRIPTION
## Summary
- Remove `Logger.Severity.Assert` from `koma-logging`
- Remove the `DefaultLogger` mapping to `Kermit.a(...)`

## Why
- `Assert` was not used by Koma's logging flow and added backend-specific API surface without a clear need for Koma users.

## Verification
- `ANDROID_HOME=/Users/h_kusu/Library/Android/sdk JAVA_HOME=/Users/h_kusu/Library/Java/JavaVirtualMachines/AndroidStudio/Contents/Home ./gradlew :koma-logging:allTests`