### PR TITLE
Rename ErrorScope to RecoverScope

### DIFF
--- a/doc/internal/adr/2026-04-30-cancel-launch-scope.md
+++ b/doc/internal/adr/2026-04-30-cancel-launch-scope.md
@@ -9,14 +9,14 @@
 
 一方で、設計上は次の 2 箇所へ広げる候補もある。
 
-- `ErrorScope`: error recovery の中で、関連する launched job も明示的に止めたい場合がある
+- `RecoverScope`: recovery の中で、関連する launched job も明示的に止めたい場合がある
 - `ActionScope.LaunchScope.TransactionScope`: launched coroutine の結果を transaction で採用するタイミングで、別の tracked launch を止めたい場合がある
 
 ここで判断したいのは、これらの候補に `cancelLaunch()` をそのまま広げるべきかどうかである。
 
 ## 決定
 
-現時点では、`cancelLaunch()` の公開範囲は `ActionScope` のまま維持し、`ErrorScope` と `ActionScope.LaunchScope.TransactionScope` への公開は見送る。
+現時点では、`cancelLaunch()` の公開範囲は `ActionScope` のまま維持し、`RecoverScope` と `ActionScope.LaunchScope.TransactionScope` への公開は見送る。
 
 - `cancelLaunch()` は、引き続き「action をきっかけに始めた tracked launch を止める API」として扱う
 - error recovery や launched coroutine 内 transaction からの lane cancellation は、現段階では標準公開しない
@@ -24,7 +24,7 @@
 
 ## 補足
 
-- `ErrorScope` は store work ではあるが、役割の中心は error recovery である。ここに lane cancellation を足すと、「エラー処理として何を回復しているのか」と「state-owned な非同期仕事をどの時点で止めるのか」が同じ場所に混ざりやすい。
+- `RecoverScope` は store work ではあるが、役割の中心は recovery である。ここに lane cancellation を足すと、「例外処理として何を回復しているのか」と「state-owned な非同期仕事をどの時点で止めるのか」が同じ場所に混ざりやすい。
 - launched job を止めたい理由が「この error 以後は古い仕事を採用したくない」なのであれば、state transition による runtime の入れ替えや、明示 action による cancellation の方が追いやすい。
 - `ActionScope.LaunchScope.TransactionScope` は一見すると有力だが、そのまま `cancelLaunch()` を公開すると self-cancel の問題がある。transaction は launched job 本体の中で直に実行されるのではなく、別 job で実行して外側が `join()` しているため、同じ explicit lane を共有している場合に自分自身の tracked launch を止められてしまう。
 - この場合、transaction 側は state 更新まで進める一方で、外側の launched job だけが cancel される形になりうるため、挙動が直感的でない。

--- a/doc/internal/adr/2026-05-01-error-dsl-exception-boundary.md
+++ b/doc/internal/adr/2026-05-01-error-dsl-exception-boundary.md
@@ -22,7 +22,7 @@ Koma の `recover {}` DSL（deprecated な `error {}` alias を含む）は、st
 `recover {}` DSL は、`Exception` を回復するための経路に限定する。
 
 - `recover<T>` の `T` は `Exception` のみを受け付ける
-- `ErrorScope.error` の型も `Exception` に限定する
+- `RecoverScope.error` の型も `Exception` に限定する
 - Store 内の recoverable path は `Exception` のみを `recover {}` に流す
 - `Exception` ではない `Throwable` は recoverable とみなさず、job failure として扱う
 - `Exception` ではない `Throwable` は `exceptionHandler()` に流れるが、`recover {}` には入れない

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreBuilder.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreBuilder.kt
@@ -122,7 +122,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
     internal val registeredExitHandlers = mutableListOf<StateHandler<(S) -> Boolean, ExitScope<S, E, S>>>()
 
     @PublishedApi
-    internal val registeredErrorHandlers = mutableListOf<StateHandler<(S, Exception) -> Boolean, ErrorScope<S, E, S, Exception>>>()
+    internal val registeredErrorHandlers = mutableListOf<StateHandler<(S, Exception) -> Boolean, RecoverScope<S, E, S, Exception>>>()
 
     private val onEnter: suspend EnterScope<S, E, S>.() -> Unit = {
         val matchingHandler = this@StoreBuilder.registeredEnterHandlers.firstOrNull { it.predicate(state) }
@@ -139,7 +139,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         matchingHandler?.handler?.invoke(this)
     }
 
-    private val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit = {
+    private val onError: suspend RecoverScope<S, E, S, Exception>.() -> Unit = {
         val matchingHandler = this@StoreBuilder.registeredErrorHandlers.firstOrNull { it.predicate(state, error) }
         matchingHandler?.handler?.invoke(this) ?: throw error
     }
@@ -174,7 +174,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
         internal val stateExitHandlers = mutableListOf<ThreadedHandler<Nothing?, ExitScope<S, E, S2>>>()
 
         @PublishedApi
-        internal val stateErrorHandlers = mutableListOf<ThreadedHandler<(Exception) -> Boolean, ErrorScope<S, E, S2, Exception>>>()
+        internal val stateErrorHandlers = mutableListOf<ThreadedHandler<(Exception) -> Boolean, RecoverScope<S, E, S2, Exception>>>()
 
         /**
          * Registers a handler to be invoked when entering this state with the specified CoroutineDispatcher.
@@ -235,14 +235,14 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
          * @param dispatcher Optional CoroutineDispatcher override for executing the recover handler
          * @param block The handler function that processes the exception and updates the state
          */
-        inline fun <reified T : Exception> recover(dispatcher: CoroutineDispatcher? = null, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
+        inline fun <reified T : Exception> recover(dispatcher: CoroutineDispatcher? = null, noinline block: suspend RecoverScope<S, E, S2, T>.() -> Unit) {
             stateErrorHandlers.add(
                 ThreadedHandler(
                     dispatcher = dispatcher,
                     predicate = { it is T },
                     handler = {
                         @Suppress("UNCHECKED_CAST")
-                        block(this as ErrorScope<S, E, S2, T>)
+                        block(this as RecoverScope<S, E, S2, T>)
                     },
                 ),
             )
@@ -255,7 +255,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             message = "Use recover<T>(dispatcher, block)",
             replaceWith = ReplaceWith("recover<T>(dispatcher, block)"),
         )
-        inline fun <reified T : Exception> error(dispatcher: CoroutineDispatcher? = null, noinline block: suspend ErrorScope<S, E, S2, T>.() -> Unit) {
+        inline fun <reified T : Exception> error(dispatcher: CoroutineDispatcher? = null, noinline block: suspend RecoverScope<S, E, S2, T>.() -> Unit) {
             recover(dispatcher, block)
         }
     }
@@ -315,7 +315,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
                     predicate = { state, throwable -> state is S2 && errorHandler.predicate(throwable) },
                     handler = {
                         @Suppress("UNCHECKED_CAST")
-                        errorHandler.invoke(this as ErrorScope<S, E, S2, Exception>)
+                        errorHandler.invoke(this as RecoverScope<S, E, S2, Exception>)
                     },
                 ),
             )
@@ -336,7 +336,7 @@ class StoreBuilder<S : State, A : Action, E : Event> internal constructor() {
             override val onEnter: suspend EnterScope<S, E, S>.() -> Unit = this@StoreBuilder.onEnter
             override val onAction: suspend ActionScope<S, A, E, S>.() -> Unit = this@StoreBuilder.onAction
             override val onExit: suspend ExitScope<S, E, S>.() -> Unit = this@StoreBuilder.onExit
-            override val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit = this@StoreBuilder.onError
+            override val onError: suspend RecoverScope<S, E, S, Exception>.() -> Unit = this@StoreBuilder.onError
         }
     }
 }

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreImpl.kt
@@ -87,7 +87,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
 
     protected abstract val onExit: suspend ExitScope<S, E, S>.() -> Unit
 
-    protected abstract val onError: suspend ErrorScope<S, E, S, Exception>.() -> Unit
+    protected abstract val onError: suspend RecoverScope<S, E, S, Exception>.() -> Unit
 
     private val coroutineScope by lazy {
         isCoroutineScopeCreated = true
@@ -654,7 +654,7 @@ internal abstract class StoreImpl<S : State, A : Action, E : Event> : Store<S, A
     private suspend fun processError(state: S, throwable: Exception): S {
         var newState: S? = null
         onError.invoke(
-            object : ErrorScope<S, E, S, Exception> {
+            object : RecoverScope<S, E, S, Exception> {
                 override val state = state
                 override val error = throwable
                 override fun nextState(block: () -> S) {

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreScope.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StoreScope.kt
@@ -414,7 +414,7 @@ typealias ActionTransactionScope<S, A, E, S2> = ActionScope.LaunchScope.Transact
  * Use this to recover from exceptions or update state accordingly.
  */
 @KomaStoreDsl
-interface ErrorScope<S : State, E : Event, S2 : S, T : Exception> : StoreScope {
+interface RecoverScope<S : State, E : Event, S2 : S, T : Exception> : StoreScope {
     /**
      * The current state snapshot when this handler is executing.
      * This value does not change immediately when a next state is registered.


### PR DESCRIPTION
## Summary
- Rename the recover handler scope type from ErrorScope to RecoverScope.
- Update StoreBuilder and StoreImpl scope signatures to use the new public type.
- Refresh internal ADR wording for the new scope name.

## Motivation
The recover DSL now uses terminology aligned with recovery instead of the deprecated error DSL naming.

## Impact
This is a source-breaking rename for consumers that referenced ErrorScope directly.

## Verification
- JAVA_HOME=/Users/h_kusu/Library/Java/JavaVirtualMachines/AndroidStudio/Contents/Home ./gradlew :koma-core:allTests