### PR TITLE
Fix inaccurate KDoc comments

### DIFF
--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -113,11 +113,6 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
 /**
  * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
- * Collecting [Store.state] may start the Store, depending on the Store's configured auto-start
- * policy. When state collection triggers startup, [ViewStore.eventEffect] starts collecting later
- * from a [LaunchedEffect], so startup events such as events emitted from an initial `enter {}`
- * handler may be emitted before handlers in the same composition begin observing them.
- *
  * The [store] lambda is used only when a new remembered Store must be created for [key].
  * For a given remembered Store instance, this function returns the same [ViewStore] instance across
  * recompositions. A new [ViewStore] is created only when a new Store instance is remembered for

--- a/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/io/github/komakt/koma/compose/ViewStore.kt
@@ -113,10 +113,10 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
 /**
  * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
- * Collecting [Store.state] starts the Store immediately.
- * Because [ViewStore.eventEffect] starts collecting later from a [LaunchedEffect], startup events
- * such as events emitted from an initial `enter {}` handler may be emitted before handlers in the
- * same composition begin observing them.
+ * Collecting [Store.state] may start the Store, depending on the Store's configured auto-start
+ * policy. When state collection triggers startup, [ViewStore.eventEffect] starts collecting later
+ * from a [LaunchedEffect], so startup events such as events emitted from an initial `enter {}`
+ * handler may be emitted before handlers in the same composition begin observing them.
  *
  * The [store] lambda is used only when a new remembered Store must be created for [key].
  * For a given remembered Store instance, this function returns the same [ViewStore] instance across

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/ExceptionHandler.kt
@@ -3,7 +3,7 @@ package io.github.komakt.koma.core
 /**
  * Handles non-fatal exceptions raised while a Store is running.
  *
- * This includes exceptions from DSL handlers, middleware, launched coroutines, and state
+ * This includes exceptions from DSL handlers, plugin hooks, launched coroutines, and state
  * persistence callbacks.
  */
 interface ExceptionHandler {

--- a/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StorePatch.kt
+++ b/koma-core/src/commonMain/kotlin/io/github/komakt/koma/core/StorePatch.kt
@@ -27,7 +27,8 @@ sealed interface PluginPatch<S : State, A : Action, E : Event> {
  * Builder used to construct a [StorePatch] via a DSL.
  *
  * This is the canonical builder shared by `:koma-test`'s public `Store.patch { ... }` extension
- * and Koma's own internal tests. It only exposes non-state Store configuration.
+ * and Koma's own internal tests. It exposes Store configuration values that can be patched before
+ * the Store has consumed them.
  */
 @Suppress("unused")
 class StorePatchBuilder<S : State, A : Action, E : Event> {

--- a/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/Logger.kt
+++ b/koma-logging/src/commonMain/kotlin/io/github/komakt/koma/logging/Logger.kt
@@ -1,7 +1,7 @@
 package io.github.komakt.koma.logging
 
 /**
- * Logging abstraction used by Koma middleware and diagnostics.
+ * Logging abstraction used by Koma plugins and diagnostics.
  */
 fun interface Logger {
     /**

--- a/koma-test/src/commonMain/kotlin/io/github/komakt/koma/test/StoreExtensions.kt
+++ b/koma-test/src/commonMain/kotlin/io/github/komakt/koma/test/StoreExtensions.kt
@@ -43,18 +43,17 @@ suspend fun <S : State, A : Action, E : Event> Store<S, A, E>.dispatchAndAwait(a
 }
 
 /**
- * Applies a non-state Store patch before the Store is started.
+ * Applies a Store configuration patch before the Store is started.
  *
  * This is intended for tests that need to swap persistence, policies, exception handling,
- * or plugins without rewriting the Store definition itself.
- * The patch must happen before APIs such as `start()`, `dispatch()`, `collectState()`, or
- * `collectEvent()` are used. Once the Store has consumed configuration values (e.g. `stateSaver`
- * is consumed once `currentState` is read; `coroutineContext` is consumed once a coroutine is
- * launched), patches that target those values will fail.
+ * plugins, or the declared initial state without rewriting the Store definition itself.
+ * The patch must happen before startup processing begins. Some values must also be patched before
+ * they are consumed: `initialState` and `stateSaver` before state is read, and `coroutineContext`
+ * before the Store launches any coroutine.
  *
  * This extension is available for Store instances created by the Koma DSL.
  *
- * @param builder Builder lambda for a non-state Store patch
+ * @param builder Builder lambda for a Store configuration patch
  * @throws IllegalStateException if the Store has already been started or is starting
  * @throws IllegalStateException if the patch targets a value that has already been consumed
  * @throws IllegalStateException if the Store is not backed by Koma's internal implementation


### PR DESCRIPTION
## Summary
- Correct KDoc for Compose Store state collection to mention auto-start policy behavior
- Update Store patch documentation now that initial state can be patched before state consumption
- Replace outdated middleware wording with plugin terminology

## Why
The previous KDoc described behavior that no longer matched the current implementation, especially around Store patching and auto-start behavior.

## Verification
- git diff --cached --check
- JAVA_HOME=/Users/h_kusu/Library/Java/JavaVirtualMachines/AndroidStudio/Contents/Home ./gradlew :koma-core:compileKotlinMetadata :koma-compose:compileKotlinMetadata :koma-logging:compileKotlinMetadata :koma-test:compileKotlinMetadata

Note: ktlintCheck was not run because the project does not define that task.