### PR TITLE
[codex] Add Store instance overload for rememberViewStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,9 +764,7 @@ class CounterViewModel @Inject constructor(
 @Composable
 fun CounterScreen(
     // create an instance of ViewStore
-    viewStore: ViewStore<CounterState, CounterAction, CounterEvent> = rememberViewStore {
-        hiltViewModel<CounterViewModel>().store
-    },
+    viewStore: ViewStore<CounterState, CounterAction, CounterEvent> = rememberViewStore(hiltViewModel<CounterViewModel>().store),
 ) {
     // ...
 
@@ -810,14 +808,22 @@ fun CounterStore(
 
 ```kt
 @Composable
-fun CounterScreen(
-    viewStore: ViewStore<CounterState, CounterAction, CounterEvent> = rememberViewStore {
+fun CounterScreen() { // wrapper for the preview-friendly CounterScreen below
+    val coroutineScope = rememberCoroutineScope()
+    val stateSaver = rememberStateSaver()
+    val viewStore: ViewStore<CounterState, CounterAction, CounterEvent> = rememberViewStore {
         CounterStore(
-            coroutineContext = rememberCoroutineScope().coroutineContext, // or, specify the autoClose option in rememberViewStore {}
-            stateSaver = rememberStateSaver(), // state persistence during screen rotation, etc.
+            coroutineContext = coroutineScope.coroutineContext, // or, specify the autoClose option in rememberViewStore{}
+            stateSaver = stateSaver, // state persistence during screen rotation, etc.
             counterRepository = CounterRepositoryImpl(),
         )
-    },
+    }
+    CounterScreen(viewStore = viewStore)
+}
+
+@Composable
+fun CounterScreen(
+    viewStore: ViewStore<CounterState, CounterAction, CounterEvent>,
 ) {
     // ...
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-koma = "4.0.0-rc02"
+koma = "4.0.0-rc03"
 agp = "9.2.1"
 kotlin = "2.3.20"
 coroutines = "1.11.0"

--- a/koma-compose/src/commonMain/kotlin/koma/compose/ViewStore.kt
+++ b/koma-compose/src/commonMain/kotlin/koma/compose/ViewStore.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.State as ComposeState
  * @param dispatch Function to dispatch actions
  * @param eventFlow Flow used to receive one-off events
  */
-@Suppress("unused")
 @Stable
 class ViewStore<S : State, A : Action, E : Event> internal constructor(
     private val stateRef: ComposeState<S>,
@@ -113,6 +112,42 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
 /**
  * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
  *
+ * Use this overload when a Store is already provided by a ViewModel or dependency injection.
+ * For a given Store instance, this function returns the same [ViewStore] instance across
+ * recompositions. A new [ViewStore] is created only when [store] changes.
+ *
+ * @param store Source Store instance
+ * @param autoClose Whether to close the Store when the composable leaves the composition
+ * @return A ViewStore state holder backed by the Store
+ */
+@Composable
+fun <S : State, A : Action, E : Event> rememberViewStore(store: Store<S, A, E>, autoClose: Boolean = false): ViewStore<S, A, E> {
+    val closeStoreOnDispose = remember(store) { autoClose }
+
+    val state = key(store) {
+        store.state.collectAsState()
+    }
+
+    DisposableEffect(store) {
+        onDispose {
+            if (closeStoreOnDispose) {
+                store.close()
+            }
+        }
+    }
+
+    return remember(store) {
+        ViewStore(
+            stateRef = state,
+            dispatch = store::dispatch,
+            eventFlow = store.event,
+        )
+    }
+}
+
+/**
+ * Remembers a [Store], collects its state as Compose state, and exposes it through a [ViewStore].
+ *
  * The [store] lambda is used only when a new remembered Store must be created for [key].
  * For a given remembered Store instance, this function returns the same [ViewStore] instance across
  * recompositions. A new [ViewStore] is created only when a new Store instance is remembered for
@@ -123,18 +158,12 @@ class ViewStore<S : State, A : Action, E : Event> internal constructor(
  *
  * @param key Key used to remember and retain the Store instance
  * @param autoClose Whether to close the Store when the composable leaves the composition
- * @param store Composable function to create the source Store instance
+ * @param store Function to create the source Store instance
  * @return A ViewStore state holder backed by the remembered Store
  */
-@Suppress("unused")
 @Composable
-fun <S : State, A : Action, E : Event> rememberViewStore(key: Any? = null, autoClose: Boolean = false, store: @Composable () -> Store<S, A, E>): ViewStore<S, A, E> {
-    val holder = remember(key) {
-        object {
-            var value: Store<S, A, E>? = null
-        }
-    }
-    val rememberedStore = holder.value ?: store().also { holder.value = it }
+fun <S : State, A : Action, E : Event> rememberViewStore(key: Any? = null, autoClose: Boolean = false, store: () -> Store<S, A, E>): ViewStore<S, A, E> {
+    val rememberedStore = remember(key) { store() }
     val closeStoreOnDispose = remember(rememberedStore) { autoClose }
 
     val state = key(rememberedStore) {

--- a/koma-compose/src/jvmTest/kotlin/koma/compose/ViewStoreJvmTest.kt
+++ b/koma-compose/src/jvmTest/kotlin/koma/compose/ViewStoreJvmTest.kt
@@ -190,6 +190,24 @@ class ViewStoreJvmTest {
     }
 
     @Test
+    fun rememberViewStore_withStoreInstanceProvidesCurrentStateAndDispatchesAction() = runTest(testDispatcher) {
+        val store = TestStore(UiState.Ready(1))
+        lateinit var viewStore: ViewStore<UiState, UiAction, UiEvent>
+
+        withComposition(
+            content = {
+                viewStore = rememberViewStore(store)
+            },
+            afterSetContent = {
+                assertEquals(UiState.Ready(1), viewStore.state)
+
+                viewStore.dispatch(UiAction.Increment)
+                assertEquals(listOf<UiAction>(UiAction.Increment), store.dispatchedActions)
+            },
+        )
+    }
+
+    @Test
     fun rememberViewStore_keepsSameInstanceWhileStateUpdates() = runTest(testDispatcher) {
         val store = TestStore(UiState.Ready(1))
         lateinit var viewStore: ViewStore<UiState, UiAction, UiEvent>


### PR DESCRIPTION
## Summary

- Add a `rememberViewStore` overload that accepts an existing `Store` instance directly.
- Change the factory overload's `store` lambda from `@Composable () -> Store<...>` to plain `() -> Store<...>`.
- Keep the factory overload for key-based Store creation and update README examples for Hilt/ViewModel and preview-friendly usage.

## Why

- The factory lambda is remembered and invoked only once per key, so making it non-composable avoids implying that composable dependencies such as `rememberCoroutineScope()` participate in recomposition when called inside it.

## Validation

- `./gradlew :koma-compose:jvmTest`
